### PR TITLE
Update kind and local path provisioner

### DIFF
--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -5,9 +5,9 @@ set -o nounset
 set -o pipefail
 
 readonly CT_VERSION=v2.2.0
-readonly KIND_VERSION=0.1.0
+readonly KIND_VERSION=0.2.1
 readonly CLUSTER_NAME=mattermost-helm-test
-readonly K8S_VERSION=v1.13.2
+readonly K8S_VERSION=v1.13.4
 
 run_ct_container() {
     echo 'Running ct container...'
@@ -38,7 +38,7 @@ create_kind_cluster() {
     chmod +x kind
     sudo mv kind /usr/local/bin/kind
 
-    kind create cluster --name "$CLUSTER_NAME" --config tests/kind-config.yaml --image "kindest/node:$K8S_VERSION"
+    kind create cluster --name "$CLUSTER_NAME" --config tests/kind-config.yaml --image "kindest/node:$K8S_VERSION" --wait 60s
 
     docker_exec mkdir -p /root/.kube
 
@@ -48,15 +48,6 @@ create_kind_cluster() {
     docker cp "$kubeconfig" ct:/root/.kube/config
 
     docker_exec kubectl cluster-info
-    echo
-
-    echo -n 'Waiting for cluster to be ready...'
-    until ! grep --quiet 'NotReady' <(docker_exec kubectl get nodes --no-headers); do
-        printf '.'
-        sleep 1
-    done
-
-    echo '✔︎'
     echo
 
     docker_exec kubectl get nodes

--- a/tests/local-path-provisioner.yaml
+++ b/tests/local-path-provisioner.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
       - name: local-path-provisioner
-        image: rancher/local-path-provisioner:v0.0.5
+        image: rancher/local-path-provisioner:v0.0.6
         imagePullPolicy: Always
         command:
         - local-path-provisioner


### PR DESCRIPTION
Update Kind version and local path provisioner

with the new kind we don't need to check if the cluster is ready, when we add the wait flag it will return when the cluster is ready