### PR TITLE
Making changes to mattermost push proxy to enable metrics, fix of mount volumes

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
-version: 0.2.0
+version: 0.2.1
 appVersion: 5.9.0
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/templates/configmap-mattermost-push-proxy.yaml
+++ b/charts/mattermost-push-proxy/templates/configmap-mattermost-push-proxy.yaml
@@ -8,5 +8,5 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "mattermost-push-proxy.chart" . }}
 data:
-  push-config.tpl: |
+  push-config.json: |
 {{include "push-config.tpl" . | printf "%s" | indent 4}}

--- a/charts/mattermost-push-proxy/templates/deployment.yaml
+++ b/charts/mattermost-push-proxy/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart:  {{ include "mattermost-push-proxy.chart" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "mattermost-push-proxy.name" . }}
@@ -18,6 +19,10 @@ spec:
       app.kubernetes.io/component: server
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.service.internalPort }}"
+        prometheus.io/path: "/metrics"
       labels:
         app.kubernetes.io/name: {{ include "mattermost-push-proxy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -32,23 +37,23 @@ spec:
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           volumeMounts:
-          - mountPath: /config/config.tpl
-            name: push-config-template
-            subPath: push-config.tpl
+            - mountPath: /config/config.json
+              name: push-config-template
+              subPath: push-config.json
           {{- if .Values.applePushSettings.apple.configMap }}
-          - mountPath: /certs/apple-push-cert.pem
-            name: apple-push-cert
-            subPath: apple-push-cert.pem
+            - mountPath: /certs/apple-push-cert.pem
+              name: apple-push-cert
+              subPath: apple-push-cert.pem
           {{- end }}
           {{- if .Values.applePushSettings.apple_rn.configMap }}
-          - mountPath: /certs/apple-rn-push-cert.pem
-            name: apple-rn-push-cert
-            subPath: apple-rn-push-cert.pem
+            - mountPath: /certs/apple-rn-push-cert.pem
+              name: apple-rn-push-cert
+              subPath: apple-rn-push-cert.pem
           {{- end }}
           {{- if .Values.applePushSettings.apple_rnbeta.configMap }}
-          - mountPath: /certs/apple-rnbeta-push-cert.pem
-            name: apple-rnbeta-push-cert
-            subPath: apple-rnbeta-push-cert.pem
+            - mountPath: /certs/apple-rnbeta-push-cert.pem
+              name: apple-rnbeta-push-cert
+              subPath: apple-rnbeta-push-cert.pem
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -61,8 +66,8 @@ spec:
           configMap:
             name: {{ include "mattermost-push-proxy.fullname" . }}-push-config-template
             items:
-            - key: push-config.tpl
-              path: push-config.tpl
+            - key: push-config.json
+              path: push-config.json
         {{- if .Values.applePushSettings.apple.configMap }}
         - name: apple-push-cert
           configMap:

--- a/charts/mattermost-push-proxy/templates/push-config.tpl
+++ b/charts/mattermost-push-proxy/templates/push-config.tpl
@@ -4,7 +4,7 @@
     "ThrottlePerSec":300,
     "ThrottleMemoryStoreSize":50000,
     "ThrottleVaryByHeader":"X-Forwarded-For",
-    "EnableMetrics": false,
+    "EnableMetrics": true,
     "ApplePushSettings":[
         {
             "Type":"apple",


### PR DESCRIPTION
Making changes to mattermost push proxy to enable metrics, fix of mount volumes

These changes were needed for the deployment of the push-proxy helm chart in k8s cluster.