### PR TITLE
Add config checksum to jobserver pod

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 0.11.1
+version: 0.11.2
 appVersion: 5.12.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -30,6 +30,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: {{ .Values.global.features.jobserver.name }}
         helm.sh/chart: {{ include "mattermost-enterprise-edition.chart" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-mattermost-config.yaml") . | sha256sum }}
     spec:
       initContainers:
       - name: "init-mattermost-app"


### PR DESCRIPTION
This adds a checksum annotation to the jobserver pod which forces a
deployment of the jobserver on a helm upgrade