### PR TITLE
Fix claimName of existing mattermost-plugins PVC

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.8.0
+version: 3.8.2
 appVersion: 5.13.2
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
       {{ if .Values.persistence.plugins.enabled }}
         persistentVolumeClaim:
           {{ if .Values.persistence.plugins.existingClaim }}
-          claimName: {{.Values.persistence.data.existingClaim }}
+          claimName: {{.Values.persistence.plugins.existingClaim }}
           {{ else }}
           claimName: {{ default (include "mattermost-team-edition.fullname" .) }}-plugins
           {{ end }}


### PR DESCRIPTION
This is a critical bugfix, without which it's not possible to deploy with customs *data* and *plugins* PVC.

The variable of *data* PVC claimName was used for the *plugins* PVC claimName, which causes error like : `Unable to mount volumes for pod XXX: timeout expired waiting for volumes to attach or mount for pod`.

Result of a `kubectl describe XXX` :
```
Volumes:
[...]
  mattermost-data:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  NAME_OF_THE_DATA_PVC
    ReadOnly:   false
  mattermost-plugins:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  NAME_OF_THE_DATA_PVC
    ReadOnly:   false
```