### PR TITLE
MM-20705 Support Kubernetes version 1.16 in mattermost-team-edition

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.8.0
+version: 3.8.3
 appVersion: 5.13.2
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -19,6 +19,8 @@ cluster using the [Helm](https://helm.sh) package manager.
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
+- Helm v2
+- [Tiller](https://rancher.com/docs/rancher/v2.x/en/installation/ha/helm-init/) (the Helm server-side component) installed on the cluster
 
 ## Installing the Chart
 
@@ -46,6 +48,7 @@ To uninstall/delete the `my-release` deployment:
 ```bash
 $ helm delete my-release
 ```
+
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 ## Configuration
@@ -115,7 +118,7 @@ configJSON:
 There is an option to use external database services (PostgreSQL or MySQL) for your Mattermost installation.
 If you use an external Database you will need to disable the MySQL chart in the `values.yaml`
 
-```Bash
+```yaml
 mysql:
   enabled: false
 ```
@@ -125,7 +128,7 @@ To use an external **PostgreSQL**, You need to set Mattermost **externalDB** con
 
 **IMPORTANT:** Make sure the DB is already created before deploying Mattermost services
 
-```Bash
+```yaml
 externalDB:
   enabled: true
   externalDriverType: "postgres"
@@ -137,11 +140,42 @@ To use an external **MySQL**, You need to set Mattermost **externalDB** config
 
 **IMPORTANT:** Make sure the DB is already created before deploying Mattermost services
 
-```Bash
+```yaml
 externalDB:
   enabled: true
   externalDriverType: "mysql"
   externalConnectionString: "<USERNAME>:<PASSWORD>@tcp(<HOST>:3306)/<DATABASE_NAME>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+```
+
+### Local development
+
+For local testing use [minikube](https://github.com/kubernetes/minikube)
+
+Create local cluster using with specified Kubernetes version (e.g. `1.15.6`)
+
+```bash
+$ minikube start --kubernetes-version v1.15.6
+```
+
+Initialize helm
+
+```bash
+$ helm init
+```
+
+Get dependencies
+
+```bash
+$ helm dependency update
+```
+
+Perform local installation
+
+```bash
+$ helm install . \
+    --set image.tag=5.12.4 \
+    --set mysql.mysqlUser=sampleUser \
+    --set mysql.mysqlPassword=samplePassword
 ```
 
 #### Limitations

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -18,7 +18,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.14+ with Beta APIs enabled
 - Helm v2
 - [Tiller](https://rancher.com/docs/rancher/v2.x/en/installation/ha/helm-init/) (the Helm server-side component) installed on the cluster
 

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -18,7 +18,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.14+ with Beta APIs enabled
+- Kubernetes 1.9+ with Beta APIs enabled
 - Helm v2
 - [Tiller](https://rancher.com/docs/rancher/v2.x/en/installation/ha/helm-init/) (the Helm server-side component) installed on the cluster
 

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{ if $ingress.enabled }}
 {{ $serviceName := include "mattermost-team-edition.name" . }}
 {{ $servicePort := .Values.service.externalPort }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "mattermost-team-edition.fullname" . }}

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{ if $ingress.enabled }}
 {{ $serviceName := include "mattermost-team-edition.name" . }}
 {{ $servicePort := .Values.service.externalPort }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "mattermost-team-edition.fullname" . }}


### PR DESCRIPTION
Relates to https://github.com/mattermost/mattermost-server/issues/13227

# What it does

This PR only address the `mattermost-team-edition`

- Updates Ingress `apiVersion` from `extensions/v1beta1` to `networking.k8s.io/v1beta1`  based on [kubernetes/kubernetes/pull/70672](https://github.com/kubernetes/kubernetes/pull/70672)
- After change bumps minimal required Kubernetes version to `1.14+`
- Fixes syntax highlighting in `README.md` markdown.
- Add *Local development* section to readme, which might help people developing locally. This can be removed if is not necessary.

# Why it is important

- Support new versions of Kubernetes

# Notes to reviewer

The PR code was tested on k8 versions: 
- `1.15.2`
- `1.16.2`

I've didn't change comment  `volume.beta.kubernetes.io/storage-class` in 
https://github.com/bpietraga/mattermost-helm/blob/support_kubernetes_1_16/charts/mattermost-team-edition/values.yaml#L27
The `volume.beta.kubernetes.io/storage-class` is being deprecated in favor `StorageClassName`, but it is just example comment and  `volume.beta.kubernetes.io/storage-class` still works