### PR TITLE
MM-20705 Use correct apiVersion based on K8s version in mattermost-push-proxy

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
-version: 0.2.3
+version: 0.3.0
 appVersion: 5.9.0
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/templates/_helpers.tpl
+++ b/charts/mattermost-push-proxy/templates/_helpers.tpl
@@ -26,3 +26,16 @@ Create chart name and version as used by the chart label.
 {{- define "mattermost-push-proxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress. Based on
+1) Helm Version (.Capabilities has been changed in v3)
+2) Kubernetes Version
+*/}}
+{{- define "mattermost-push-proxy.ingress.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+"extensions/v1beta1"
+{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}

--- a/charts/mattermost-push-proxy/templates/ingress.yaml
+++ b/charts/mattermost-push-proxy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $serviceName := include "mattermost-push-proxy.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "mattermost-push-proxy.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "mattermost-push-proxy.fullname" . }}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Originally in #126 there was an attempt to change the chart to consider deprecated Kubernetes API (namely in 1.16) this PR is to complete that. Instead of completely drop the support for older API version this PR reads the Kubernetes Version from Helm's `Capabilities` built-in objects and executes `semverCompare` against the underlying K8s version and known version in which given API was deprecated.

#### Corresponding PRs

enterprise-edition: #134 
team-edition: #132 

#### Ticket Link

Relates to #126 and mattermost/mattermost-server#13227

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

