### PR TITLE
MM-20705 Use correct apiVersion based on K8s version in mattermost-enterprise-edition

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.0.1
+version: 1.1.0
 appVersion: 5.15.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/_helpers.tpl
+++ b/charts/mattermost-enterprise-edition/templates/_helpers.tpl
@@ -41,4 +41,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s-%s" .Release.Name $name .Values.global.features.jobserver.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-
+{{/*
+Return the appropriate apiVersion for ingress. Based on
+1) Helm Version (.Capabilities has been changed in v3)
+2) Kubernetes Version
+*/}}
+{{- define "mattermost-enterprise-edition.ingress.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+"extensions/v1beta1"
+{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}

--- a/charts/mattermost-enterprise-edition/templates/ingress-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/ingress-mattermost-app.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.mattermostApp.ingress.enabled -}}
 {{- $serviceName := include "mattermost-enterprise-edition.fullname" . -}}
 {{- $servicePort := .Values.mattermostApp.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "mattermost-enterprise-edition.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "mattermost-enterprise-edition.fullname" . }}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Originally in #126 there was an attempt to change the chart to consider deprecated Kubernetes API (namely in 1.16) this PR is to complete that. Instead of completely drop the support for older API version this PR reads the Kubernetes Version from Helm's `Capabilities` built-in objects and executes `semverCompare` against the underlying K8s version and known version in which given API was deprecated.

#### Corresponding PRs

push-proxy: #133 
team-edition: #132 

#### Ticket Link

Relates to #126 and mattermost/mattermost-server#13227

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

