### PR TITLE
Added opportunity assign pods to nodes and service can be NodePort

### DIFF
--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -31,6 +31,18 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
     spec:
+      {{- if .Values.assigning.affinity }}
+      affinity:
+{{ toYaml .Values.assigning.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.assigning.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.assigning.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.assigning.tolerations }}
+      tolerations:
+{{ toYaml .Values.assigning.tolerations | indent 8 }}
+      {{- end }}
       initContainers:
       {{- if not .Values.externalDB.enabled }}
       - name: "init-mysql"

--- a/charts/mattermost-team-edition/templates/service.yaml
+++ b/charts/mattermost-team-edition/templates/service.yaml
@@ -22,6 +22,9 @@ spec:
     targetPort: http
     protocol: TCP
     name: {{  include "mattermost-team-edition.name" . }}
+{{- if and (.Values.service.nodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
 {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -40,11 +40,20 @@ persistence:
     accessMode: ReadWriteOnce
   # existingClaim: ""
 
+assigning:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 service:
   type: ClusterIP
   externalPort: 8065
   internalPort: 8065
   annotations: {}
+  ## Port to expose on each node
+  ## Only used if service.type is 'NodePort'
+  ##
+  nodePort: 30065
   loadBalancerSourceRanges: []
 
 ingress:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
* Affinity, NodeSelector and tolerations added to spec of Deployment
* NodePort choice added to Service 

#### Ticket Link
No ticket
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

