### PR TITLE
FIX: plugins tar and rm expression

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.1.0
+version: 1.1.1
 appVersion: 5.15.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -149,8 +149,8 @@ mattermostApp:
     #       do
     #         wget ${plugin_tar} -P /mattermost/plugins
     #         cd /mattermost/plugins
-    #         tar -xzvf ${plugin_tar}
-    #         rm -f ${plugin_tar}
+    #         tar -xzvf ${plugin_tar##*/}
+    #         rm -f ${plugin_tar##*/}
     #       done
     #   volumeMounts:
     #   # Need to match the volume mount for plugins volumes


### PR DESCRIPTION
#### Summary
Fixes the extraction and removal of downloaded Plugin archives in the `extraInitContainers` section of the **Mattermost Enterprise** Helm chart.

Before, it tried to extract and remove the whole plugin URL - now it extracts the filename of the URL and uses only this part.
