### PR TITLE
Bump mm ee to 5.23.1 and dependecies updates

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.2.0
-appVersion: 5.15.0
+version: 1.3.0
+appVersion: 5.23.1
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-enterprise-edition/requirements.lock
+++ b/charts/mattermost-enterprise-edition/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mysqlha
   repository: https://kubernetes-charts-incubator.storage.googleapis.com
-  version: 0.4.0
+  version: 2.0.0
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 2.5.0
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 7.1.0
-digest: sha256:7b0ca1f05f3ec57c9ff06714e0243c32d4abe05567d57b0edf7a0e2137885fb1
-generated: "2019-07-15T18:18:05.92624+02:00"
+digest: sha256:cab78d17ba2d010d909c61e584932c99e41b9a50b2ac216ee3b528f85b5cb07f
+generated: "2020-06-09T14:09:10.993279+02:00"

--- a/charts/mattermost-enterprise-edition/requirements.lock
+++ b/charts/mattermost-enterprise-edition/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.0.0
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 2.5.0
+  version: 5.0.26
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 7.1.0
-digest: sha256:cab78d17ba2d010d909c61e584932c99e41b9a50b2ac216ee3b528f85b5cb07f
-generated: "2020-06-09T14:09:10.993279+02:00"
+  version: 11.4.0
+digest: sha256:c0daace187ec1da07c375a07dbb3d9cb16261d47e6f080ddb2aa744db0d724da
+generated: "2020-06-09T14:19:29.905177+02:00"

--- a/charts/mattermost-enterprise-edition/requirements.yaml
+++ b/charts/mattermost-enterprise-edition/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: mysqlha
     repository: https://kubernetes-charts-incubator.storage.googleapis.com
-    version: 0.4.0
+    version: 2.0.0
     condition: global.features.database.useInternal
   - name: minio
     repository: https://kubernetes-charts.storage.googleapis.com

--- a/charts/mattermost-enterprise-edition/requirements.yaml
+++ b/charts/mattermost-enterprise-edition/requirements.yaml
@@ -5,9 +5,9 @@ dependencies:
     condition: global.features.database.useInternal
   - name: minio
     repository: https://kubernetes-charts.storage.googleapis.com
-    version: 2.5.0
+    version: 5.0.26
     condition: minio.enabled
   - name: prometheus
     repository: https://kubernetes-charts.storage.googleapis.com
-    version: 7.1.0
+    version: 11.4.0
     condition: global.features.grafana.enabled

--- a/charts/mattermost-enterprise-edition/templates/tests/mattermost-app-config-test.yaml
+++ b/charts/mattermost-enterprise-edition/templates/tests/mattermost-app-config-test.yaml
@@ -2,8 +2,16 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include  "mattermost-enterprise-edition.fullname" . }}-app-tests
+  labels:
+    app.kubernetes.io/name: {{ include "mattermost-enterprise-edition.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "mattermost-enterprise-edition.chart" . }}
 data:
   run.sh: |-
+    #!/usr/bin/env bats
     @test "Testing Mattermost is accessible" {
-      curl --retry 48 --retry-delay 10 {{ include "mattermost-enterprise-edition.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.mattermostApp.service.internalPort }}
+      url="http://{{ include "mattermost-enterprise-edition.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.mattermostApp.service.internalPort }}"
+      code=$(wget --server-response --spider --timeout 10 --tries 1 ${url} 2>&1 | awk '/^  HTTP/{print $2}')
+      [ "$code" == "200" ]
     }

--- a/charts/mattermost-enterprise-edition/templates/tests/mattermost-app-test.yaml
+++ b/charts/mattermost-enterprise-edition/templates/tests/mattermost-app-test.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   initContainers:
   - name: "test-framework"
-    image: "dduportal/bats:0.4.0"
+    image: bats/bats:v1.1.0
     command:
     - "bash"
     - "-c"

--- a/charts/mattermost-enterprise-edition/templates/tests/mattermost-app-test.yaml
+++ b/charts/mattermost-enterprise-edition/templates/tests/mattermost-app-test.yaml
@@ -2,27 +2,19 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include  "mattermost-enterprise-edition.fullname" . }}-app-test-{{ randAlphaNum 5 | lower }}"
+  labels:
+    app.kubernetes.io/name: {{ include "mattermost-enterprise-edition.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "mattermost-enterprise-edition.chart" . }}
   annotations:
     "helm.sh/hook": test-success
 spec:
-  initContainers:
-  - name: "test-framework"
-    image: bats/bats:v1.1.0
-    command:
-    - "bash"
-    - "-c"
-    - |
-      set -ex
-      # copy bats to tools dir
-      cp -R /usr/local/libexec/ /tools/bats/
-    volumeMounts:
-    - mountPath: /tools
-      name: tools
   containers:
   - name: {{ .Release.Name }}-app-test
-    image: cosmintitei/bash-curl:latest
+    image: bats/bats:v1.1.0
     imagePullPolicy: Always
-    command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+    command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
     volumeMounts:
     - mountPath: /tests
       name: tests

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -92,7 +92,7 @@ mattermostApp:
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
-    tag: 5.15.0
+    tag: 5.23.1
     pullPolicy: IfNotPresent
 
   strategy:


### PR DESCRIPTION
#### Summary
update mm ee to use 5.23.1
and also the dependencies because the current ones does not work in clusters >1.15

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

