### PR TITLE
deps: bump mysql helm chart dependency

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.11.2
+version: 3.11.3
 appVersion: 5.23.1
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/requirements.lock
+++ b/charts/mattermost-team-edition/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mysql
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.4.0
-digest: sha256:4b20e3573573e7e9747fe67675fa188ecf1abf048b841960015396d7637a328e
-generated: "2019-10-14T09:46:28.877744+03:00"
+  version: 1.6.4
+digest: sha256:c01c8079f99eb300f749c31728fbb5794cbd9f1fe8690d1e762cdc240201ddbb
+generated: "2020-06-10T10:32:13.954779+02:00"

--- a/charts/mattermost-team-edition/requirements.yaml
+++ b/charts/mattermost-team-edition/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mysql
-  version: 1.4.0
+  version: 1.6.4
   repository: https://kubernetes-charts.storage.googleapis.com
   condition: mysql.enabled


### PR DESCRIPTION
#### Summary
deps: bump mysql helm chart dependency

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

