### PR TITLE
[GH-162] Added required ENV vars to use MinIO storage when enabled in values

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.5.0
+version: 1.6.0
 appVersion: 5.24.2
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.6.0
+version: 1.5.1
 appVersion: 5.24.2
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -99,6 +99,8 @@ spec:
           value: "true"
 {{- end }}
 {{- if .Values.minio.enabled }}
+        - name: MM_FILESETTINGS_DRIVERNAME
+          value: "amazons3"
         - name: MM_FILESETTINGS_AMAZONS3ACCESSKEYID
           value: "{{ .Values.minio.accessKey }}"
         - name: MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY
@@ -107,6 +109,8 @@ spec:
           value: "{{ .Values.minio.defaultBucket.name }}"
         - name: MM_FILESETTINGS_AMAZONS3ENDPOINT
           value: "{{ .Release.Name }}-minio:9000"
+        - name: MM_FILESETTINGS_AMAZONS3SSL
+          value: "false"
 {{- end }}
 {{- if .Values.global.features.jobserver.enabled }}
         - name: MM_JOBSETTINGS_RUNJOBS


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR sets the `DriverName` to `amazons3`. It means that Mattermost will be able to use MinIO storage when `minio.enabled` is set to `true` in values.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-helm/issues/162
