### PR TITLE
support loadbalancerIP in Team edition

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.13.3
+version: 3.14.0
 appVersion: 5.25.2
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -85,6 +85,7 @@ Parameter                             | Description                             
 `extraEnvVars`                        | Extra environments variables to be used in the deployments                                      | `[]`
 `extraInitContainers`                 | Additional init containers                                                                      | `[]`
 `service.annotations`                 | Service annotations                                                                             | `{}`
+`service.loadBalancerIP`              | A user-specified IP address for service type LoadBalancer to use as External IP (if supported)  | `nil`
 `service.loadBalancerSourceRanges`    | list of IP CIDRs allowed access to load balancer (if supported)                                 | `[]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/charts/mattermost-team-edition/templates/NOTES.txt
+++ b/charts/mattermost-team-edition/templates/NOTES.txt
@@ -2,6 +2,21 @@ You can easily connect to the remote instance from your browser. Forward the web
 
 - kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mattermost-team-edition.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }') 8080:8065
 
+{{ if eq .Values.service.type "LoadBalancer"}}
+{{- if .Values.service.loadBalancerIP }}
+Mattermost will be available at:
+
+  {{ .Values.service.loadBalancerIP }}:{{ .Values.service.externalPort }}
+
+{{ else }}
+You can connect to Mattermost by using the IP printed by this commmand on port {{ .Values.service.externalPort }}:
+
+  MATTERMOST_IP=`kubectl get --namespace {{ .Release.Namespace }} service {{  include "mattermost-team-edition.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+  echo $MATTERMOST_IP
+
+{{ end }}
+{{ end }}
+
 {{ if .Values.ingress.enabled }}
 
 Mattermost will be available at the URL, if you setup the nginx-ingress or other type of ingress:

--- a/charts/mattermost-team-edition/templates/service.yaml
+++ b/charts/mattermost-team-edition/templates/service.yaml
@@ -22,6 +22,9 @@ spec:
     targetPort: http
     protocol: TCP
     name: {{  include "mattermost-team-edition.name" . }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
 {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -45,6 +45,7 @@ service:
   externalPort: 8065
   internalPort: 8065
   annotations: {}
+  # loadBalancerIP:
   loadBalancerSourceRanges: []
 
 ingress:


### PR DESCRIPTION
Signed-off-by: Dennis Zhang <dennis.zhang.nrg@gmail.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I'd like for this helm chart to support loadbalancerIP for use with external loadbalancers in the cloud or MetalLB on baremetal.
Thanks.

Notes outputs:

With loadbalancerIP specified while using service type LoadBalancer example:
```
Mattermost will be available at:

  192.168.1.56:80
```

Without loadbalancerIP specified while using service type LoadBalancer example:

```
You can connect to Mattermost by using the IP printed by this commmand on port 80:

  MATTERMOST_IP=`kubectl get --namespace mattermost service mattermost-team-edition -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
  echo $MATTERMOST_IP
```

Running the printed command:
```
$   MATTERMOST_IP=`kubectl get --namespace mattermost service mattermost-team-edition -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
$   echo $MATTERMOST_IP
192.168.1.56
```

MetalLB using the value to assign IP :
```
kubectl -n mattermost describe service mattermost-team-edition
...
Events:
  Type    Reason          Age                    From                Message
  ----    ------          ----                   ----                -------
  Normal  LoadbalancerIP  2m22s (x3 over 3h32m)  service-controller  -> 192.168.1.56
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
N/A
