### PR TITLE
Fix data/plugin folders mounted as root

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.15.1
+version: 3.15.2
 appVersion: 5.26.1
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 12 }}
-      {{ if and (lt ((.Values.image.tag | semver) | (semver "5.14").Compare) 1) (or .Values.persistence.data.enabled .Values.persistence.plugins.enabled) }}
+      {{ if and (semverCompare ">= 5.14" .Values.image.tag) (or .Values.persistence.data.enabled .Values.persistence.plugins.enabled) }}
       securityContext:
         fsGroup: 2000
         runAsGroup: 2000

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -80,6 +80,12 @@ spec:
         {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 12 }}
+      {{ if and (lt ((.Values.image.tag | semver) | (semver "5.14").Compare) 1) (or .Values.persistence.data.enabled .Values.persistence.plugins.enabled) }}
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 2000
+        runAsUser: 2000
+      {{ end }}
       volumes:
       {{- if .Values.extraVolumes -}}
       {{ .Values.extraVolumes | toYaml | nindent 6 }}

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -80,11 +80,15 @@ spec:
         {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 12 }}
-      {{ if and (semverCompare ">= 5.14" .Values.image.tag) (or .Values.persistence.data.enabled .Values.persistence.plugins.enabled) }}
+      {{- if or .Values.persistence.data.enabled .Values.persistence.plugins.enabled }}
       securityContext:
+      {{- if .Values.securityContext }}
+      {{- .Values.securityContext | toYaml | nindent 8 }}
+      {{- else if (semverCompare ">= 5.14" .Values.image.tag) }}
         fsGroup: 2000
         runAsGroup: 2000
         runAsUser: 2000
+      {{- end -}}
       {{ end }}
       volumes:
       {{- if .Values.extraVolumes -}}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -40,6 +40,15 @@ persistence:
     accessMode: ReadWriteOnce
   # existingClaim: ""
 
+## Enable securityContext for process and volume mounting ownership
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext: {}
+  # Default values are 2000 if with the official Mattermost image >=5.14 or root (not set) below
+  # fsGroup:
+  # runAsGroup:
+  # runAsUser:
+
 service:
   type: ClusterIP
   externalPort: 8065


### PR DESCRIPTION
Due to mattermost image needs mattermost ownership for version >= 5.14

#### Summary

Mount volumes as mattermost user if mattermost image is greater than 5.14 (first version to use mattermost user to run processes in the container)

#### Ticket Link

Fixes #129, #139, #142

