### PR TITLE
Change mm_config to be created as a secret and mounted

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.10.1
+version: 1.10.2
 appVersion: 5.28.1
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -80,11 +80,10 @@ spec:
           name: gossip
         env:
         - name: MM_CONFIG
-{{- if .Values.global.features.database.useInternal }}
-          value: "mysql://{{ .Values.mysqlha.mysqlha.mysqlUser }}:{{ .Values.mysqlha.mysqlha.mysqlPassword }}@tcp({{ .Release.Name }}-mysqlha-0.{{ .Release.Name }}-mysqlha:3306)/{{ .Values.mysqlha.mysqlha.mysqlDatabase }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
-{{- else }}
-          value: "{{ .Values.global.features.database.external.driver }}://{{ .Values.global.features.database.external.dataSource }}"
-{{- end }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "mattermost-enterprise-edition.fullname" . }}-mattermost-dbsecret
+              key: mattermost.dbsecret
         - name: MM_SERVICESETTINGS_SITEURL
           value: "{{ .Values.global.siteUrl }}"
         - name: MM_SERVICESETTINGS_LISTENADDRESS

--- a/charts/mattermost-enterprise-edition/templates/secret-mattermost-dbsecret.yaml
+++ b/charts/mattermost-enterprise-edition/templates/secret-mattermost-dbsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mattermost-enterprise-edition.fullname" . }}-mattermost-dbsecret
+  labels:
+    app.kubernetes.io/name: {{ include "mattermost-enterprise-edition.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart:  {{ include "mattermost-enterprise-edition.chart" . }}
+type: Opaque
+data:
+{{- if .Values.global.features.database.useInternal }}
+  mattermost.dbsecret: "mysql://{{ .Values.mysqlha.mysqlha.mysqlUser }}:{{ .Values.mysqlha.mysqlha.mysqlPassword }}@tcp({{ .Release.Name }}-mysqlha-0.{{ .Release.Name }}-mysqlha:3306)/{{ .Values.mysqlha.mysqlha.mysqlDatabase }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+{{- else }}
+  mattermost.dbsecret: "{{ .Values.global.features.database.external.driver }}://{{ .Values.global.features.database.external.dataSource }}"
+{{- end }}

--- a/charts/mattermost-enterprise-edition/templates/secret-mattermost-dbsecret.yaml
+++ b/charts/mattermost-enterprise-edition/templates/secret-mattermost-dbsecret.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.global.features.database.useInternal }}
-  mattermost.dbsecret: "mysql://{{ .Values.mysqlha.mysqlha.mysqlUser }}:{{ .Values.mysqlha.mysqlha.mysqlPassword }}@tcp({{ .Release.Name }}-mysqlha-0.{{ .Release.Name }}-mysqlha:3306)/{{ .Values.mysqlha.mysqlha.mysqlDatabase }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+  mattermost.dbsecret: {{ tpl  "mysql://{{ .Values.mysqlha.mysqlha.mysqlUser }}:{{ .Values.mysqlha.mysqlha.mysqlPassword }}@tcp({{ .Release.Name }}-mysqlha-0.{{ .Release.Name }}-mysqlha:3306)/{{ .Values.mysqlha.mysqlha.mysqlDatabase }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" . | b64enc }}
 {{- else }}
-  mattermost.dbsecret: "{{ .Values.global.features.database.external.driver }}://{{ .Values.global.features.database.external.dataSource }}"
+  mattermost.dbsecret: {{ tpl "{{ .Values.global.features.database.external.driver }}://{{ .Values.global.features.database.external.dataSource }}" . | b64enc }}
 {{- end }}


### PR DESCRIPTION
#### Summary
<!--
This pull request changes mattermost helm installation to create a secret containing the mm_config secret instead of assigning it  as an environment variable 
-->


