### PR TITLE
Add nodeSelector support for helm chart

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.12.0
+version: 1.13.0
 appVersion: 5.29.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -37,8 +37,17 @@ spec:
         {{- .Values.mattermostApp.extraPodAnnotations | toYaml | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.mattermostApp.affinity}}
-      {{- .Values.mattermostApp.affinity | toYaml | nindent 6 }}
+      {{- if .Values.mattermostApp.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.mattermostApp.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.mattermostApp.affinity }}
+      affinity:
+        {{ toYaml .Values.mattermostApp.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.mattermostApp.tolerations }}
+      tolerations:
+        {{ toYaml .Values.mattermostApp.tolerations | indent 8 }}
       {{- end }}
       {{ if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -35,6 +35,18 @@ spec:
         {{- .Values.mattermostApp.extraPodAnnotations | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.global.features.jobserver.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.global.features.jobserver.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.global.features.jobserver.affinity }}
+      affinity:
+        {{ toYaml .Values.global.features.jobserver.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.global.features.jobserver.tolerations }}
+      tolerations:
+        {{ toYaml .Values.global.features.jobserver.tolerations | indent 8 }}
+      {{- end }}
       initContainers:
       - name: "init-mattermost-app"
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-loadtest.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-loadtest.yaml
@@ -31,6 +31,18 @@ spec:
         app.kubernetes.io/component: loadtest
         helm.sh/chart: {{ include "mattermost-enterprise-edition.chart" . }}
     spec:
+      {{- if .Values.global.features.loadtest.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.global.features.loadtest.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.global.features.loadtest.affinity }}
+      affinity:
+        {{ toYaml .Values.global.features.loadtest.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.global.features.loadtest.tolerations }}
+      tolerations:
+        {{ toYaml .Values.global.features.loadtest.tolerations | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "mattermost-enterprise-edition.name" .}}-loadtest
           image: "{{ .Values.global.features.loadTest.image.repository }}:{{ .Values.global.features.loadTest.image.tag }}"

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -47,6 +47,15 @@ global:
       service:
         name: mattermost-app-jobserver
         type: ClusterIP
+      # jobserver Node selector
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+      nodeSelector: {}
+      # jobserver Affinity
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+      affinity: {}
+      # jobserver Tolerations for pod assignment
+      # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      tolerations: []
     notifications:
       # Push proxy must be configured or useHPNS must be true for push noticiations to work.
       push:
@@ -85,6 +94,15 @@ global:
       resultsChannelId: ""
       resultsUsername: ""
       resultsPassword: ""
+      # loadTest Node selector
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+      nodeSelector: {}
+      # loadTest Affinity
+      # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+      affinity: {}
+      # loadTest Tolerations for pod assignment
+      # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+      tolerations: []
 
 initContainerImage:
   repository: appropriate/curl
@@ -147,8 +165,17 @@ mattermostApp:
     targetMemoryUtilizationPercentage: 50
     targetCPUUtilizationPercentage: 50
 
+  # mattermostApp Node selector
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  # mattermostApp Affinity
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
-    ## See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
+
+  # mattermostApp Tolerations for pod assignment
+  # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 
   resources: {}
     # limits:

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.20.1
+version: 3.21.0
 appVersion: 5.29.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -31,6 +31,18 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
     spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
       initContainers:
       {{- if not .Values.externalDB.enabled }}
       - name: "init-mysql"

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -192,7 +192,6 @@ affinity: {}
 
 ## Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-##
 tolerations: []
 
 # NOTE: These acts as the default values for the config.json file read by the

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -182,6 +182,19 @@ extraVolumeMounts: []
   #   mountPath: /host/var/log
   #   readOnly: true
 
+## Node selector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+## Affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
 # NOTE: These acts as the default values for the config.json file read by the
 # mattermost server itself. You can override the configJSON object just like any
 # Helm template value. Since it is an object, the object you provide will merge


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adding support to specify nodeSelector, affinity and tolerations for deployments/pods.

#### Ticket Link
N/A
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

