### PR TITLE
Upgrade helm and chart-testing to latest and fix e2e issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
   lint-charts:
     docker:
-      - image: quay.io/helmpack/chart-testing:v2.4.1
+      - image: quay.io/helmpack/chart-testing:v3.3.1
     steps:
       - checkout
       - run:

--- a/.circleci/install_tools.sh
+++ b/.circleci/install_tools.sh
@@ -2,16 +2,15 @@
 
 set -o errexit
 
-readonly HELM_VERSION=2.16.7
+readonly HELM_VERSION=3.4.1
 readonly CHART_RELEASER_VERSION=1.0.0-beta.1
 
 echo "Installing Helm..."
-curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-v$HELM_VERSION-linux-amd64.tar.gz"
+curl -LO "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz"
 sudo mkdir -p "/usr/local/helm-v$HELM_VERSION"
 sudo tar -xzf "helm-v$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-v$HELM_VERSION"
 sudo ln -s "/usr/local/helm-v$HELM_VERSION/linux-amd64/helm" /usr/local/bin/helm
 rm -f "helm-v$HELM_VERSION-linux-amd64.tar.gz"
-helm init --client-only
 
 echo "Installing chart-releaser..."
 curl -LO "https://github.com/helm/chart-releaser/releases/download/v${CHART_RELEASER_VERSION}/chart-releaser_${CHART_RELEASER_VERSION}_linux_amd64.tar.gz"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tags
 .init
 
 charts/mattermost-enterprise-edition/charts/*.tgz
+charts/mattermost-team-edition/charts/*.tgz

--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.11.0
+version: 1.12.0
 appVersion: 5.29.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -17,6 +17,6 @@ maintainers:
     email: joram@mattermost.com
   - name: stylianosrigas
     email: stylianos@mattermost.com
-source:
+sources:
 - https://github.com/mattermost/mattermost-server
 - https://github.com/mattermost/mattermost-helm

--- a/charts/mattermost-enterprise-edition/README.md
+++ b/charts/mattermost-enterprise-edition/README.md
@@ -27,7 +27,7 @@ Once Helm is installed and initialized, run the following:
 
 ```bash
 helm repo add mattermost https://helm.mattermost.com
-helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+helm repo add incubator https://charts.helm.sh/incubator
 ```
 
 ## 1.3 Ingress

--- a/charts/mattermost-enterprise-edition/ci/init-container-values.yaml
+++ b/charts/mattermost-enterprise-edition/ci/init-container-values.yaml
@@ -24,11 +24,11 @@ mattermostApp:
   extraVolumeMounts:
     - mountPath: /tmp/test-tmp
       name: varlog
+      readOnly: true
 
   extraVolumes:
     - name: varlog
       emptyDir: {}
-      readOnly: true
 
 mysqlha:
   mysqlha:

--- a/charts/mattermost-enterprise-edition/requirements.lock
+++ b/charts/mattermost-enterprise-edition/requirements.lock
@@ -1,4 +1,10 @@
 dependencies:
+- name: mattermost-elasticsearch
+  repository: ""
+  version: 0.1.0
+- name: mattermost-grafana
+  repository: ""
+  version: 0.3.6
 - name: mysqlha
   repository: https://charts.helm.sh/incubator
   version: 2.0.0
@@ -8,5 +14,5 @@ dependencies:
 - name: prometheus
   repository: https://charts.helm.sh/stable
   version: 11.4.0
-digest: sha256:166598e7cb93d922f76863fb5d11263c596cd3120c868eb6c380fa4d681a4e1a
-generated: "2020-11-12T16:20:05.612311+01:00"
+digest: sha256:fa90782b768ec2654b9763569f86aab463052b1877feff8a05e5b04e364c5582
+generated: "2021-01-27T14:11:21.326738823-05:00"

--- a/charts/mattermost-enterprise-edition/requirements.yaml
+++ b/charts/mattermost-enterprise-edition/requirements.yaml
@@ -1,4 +1,8 @@
 dependencies:
+  - name: mattermost-elasticsearch
+    version: 0.1.0
+  - name: mattermost-grafana
+    version: 0.3.6
   - name: mysqlha
     repository: https://charts.helm.sh/incubator
     version: 2.0.0

--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -16,6 +16,6 @@ maintainers:
     email: carlos@mattermost.com
   - name: jwilander
     email: joram@mattermost.com
-source:
+sources:
 - https://github.com/mattermost/mattermost-helm
 - https://github.com/mattermost/mattermost-push-proxy

--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
-version: 0.5.0
+version: 0.6.0
 appVersion: 5.22.4
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/README.md
+++ b/charts/mattermost-push-proxy/README.md
@@ -25,7 +25,7 @@ Once Helm is installed and initialized, run the following:
 
 ```bash
 helm repo add mattermost https://helm.mattermost.com
-helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+helm repo add incubator https://charts.helm.sh/incubator
 ```
 
 # 2. Configuration

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.19.0
+version: 3.20.0
 appVersion: 5.29.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 - team collaboration
 home: https://mattermost.com
 icon: http://www.mattermost.org/wp-content/uploads/2016/04/icon.png
-source:
+sources:
 - https://github.com/mattermost/mattermost-server
 - https://github.com/mattermost/mattermost-helm
 maintainers:

--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -3,4 +3,4 @@ target-branch: master
 chart-repos:
   - incubator=https://charts.helm.sh/incubator
   - stable=https://charts.helm.sh/stable
-helm-extra-args: --timeout 800
+helm-extra-args: --timeout 5m0s

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -4,8 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v2.4.1
-readonly KIND_VERSION=v0.8.1
+readonly CT_VERSION=v3.3.1
+readonly KIND_VERSION=v0.9.0
 readonly CLUSTER_NAME=mattermost-helm-test
 
 run_ct_container() {
@@ -55,14 +55,6 @@ create_kind_cluster() {
     echo
 }
 
-install_tiller() {
-    echo 'Installing Tiller...'
-    docker_exec kubectl --namespace kube-system create sa tiller
-    docker_exec kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-    docker_exec helm init --service-account tiller --upgrade --wait
-    echo
-}
-
 install_charts() {
     docker_exec ct install
     echo
@@ -80,7 +72,6 @@ main() {
 
     echo 'Chart changes detected.'
     create_kind_cluster
-    install_tiller
     install_charts
 }
 

--- a/tests/kind-config.yaml
+++ b/tests/kind-config.yaml
@@ -2,10 +2,10 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
   - role: worker
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
   - role: worker
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
   - role: worker
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Update `helmpack/chart-testing` image to `v3.3.1` and fix linting issues due to upgrade of the image and the fact that Helm 2 is deprecated in the process.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

