### PR TITLE
Update ingress template to allow quoted hostnames/wildcards

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.21.0
+version: 3.22.0
 appVersion: 5.29.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   rules:
   {{ range $host := $ingress.hosts }}
-  - host: {{ $host }}
+  - host: {{ $host | quote }}
     http:
       paths:
       - path: {{ $ingress.path }}


### PR DESCRIPTION
#### Summary
<!--
Kubernetes ingress resource allows hostnames prepended with wildcards. There is a requirement that hostnames that include wildcards must be contained within quotes. 
The current mattermost-team-edition helm chart does not allow for the use of quotes with host values. This prevents users from using wildcards in the ingress hostnames. 
This change allows the use of quotes, and therefore enables the use of wildcards in ingress hostnames. 
-->


