### PR TITLE
[mattermost-team-edition] add configuration to persist mattermost config json

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.22.0
+version: 3.23.0
 appVersion: 5.29.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -53,6 +53,27 @@ spec:
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}
       {{- end }}
+      {{- if .Values.persistence.config.enabled }}
+      - name: "init-config"
+        image: "{{ .Values.persistence.config.initContainerImage.repository }}:{{ .Values.persistence.config.initContainerImage.tag }}"
+        imagePullPolicy: {{ .Values.persistence.config.initContainerImage.imagePullPolicy }}
+        command:
+          - sh
+          - -c
+          - |
+            if test -f /persist-config/config.json; then
+              echo "config exists"
+            else
+              echo "creating initial config"
+              cp /init-config/config.json /persist-config/
+              chmod 0664 /persist-config/config.json
+            fi
+        volumeMounts:
+          - mountPath: "/init-config"
+            name: config-json
+          - mountPath: "/persist-config"
+            name: persistent-config
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -80,9 +101,14 @@ spec:
             path: /api/v4/system/ping
             port: http
         volumeMounts:
+        {{- if .Values.persistence.config.enabled }}
+        - mountPath: /mattermost/config
+          name: persistent-config
+        {{- else }}
         - mountPath: /mattermost/config/config.json
           name: config-json
           subPath: config.json
+        {{- end }}
         - mountPath: /mattermost/data
           name: mattermost-data
         - mountPath: /mattermost/{{ trimPrefix "./" .Values.configJSON.PluginSettings.Directory }}
@@ -99,6 +125,11 @@ spec:
       - name: config-json
         secret:
           secretName: {{ include "mattermost-team-edition.fullname" . }}-config-json
+      {{- if .Values.persistence.config.enabled }}
+      - name: persistent-config
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.config.existingClaim | default (include "mattermost-team-edition.fullname" .) }}-config
+      {{- end }}
       - name: mattermost-data
       {{ if .Values.persistence.data.enabled }}
         persistentVolumeClaim:

--- a/charts/mattermost-team-edition/templates/pvc-config.yaml
+++ b/charts/mattermost-team-edition/templates/pvc-config.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "mattermost-team-edition.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "mattermost-team-edition.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
+  annotations:
+  {{- range $key, $value := .Values.persistence.config.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  accessModes:
+  - {{ .Values.persistence.config.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- if .Values.persistence.config.storageClass }}
+{{- if (eq "-" .Values.persistence.config.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.config.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -39,6 +39,25 @@ persistence:
     # storageClass:
     accessMode: ReadWriteOnce
   # existingClaim: ""
+  ## This volume persists the Mattermost configuration to a volume, so the application itself can make configuration changes
+  ## Note that if `persistence.config.enabled` is `true`, the `configJSON` value will only be respected on initial install
+  ##
+  config:
+    enabled: true
+    size: 50Mi
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    accessMode: ReadWriteOnce
+  # existingClaim: ""
+
+    ## The init container used for seeding the initial configJSON
+    ##
+    initContainerImage:
+      repository: alpine
+      tag: 3.13.1
+      imagePullPolicy: IfNotPresent
 
 service:
   type: ClusterIP


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Before this change, there was no way to allow mattermost instances deployed via this chart to persist updates to its configuration.  This is because the configuration is controlled by helm, and is provided to the app using a read-only filesystem, which is a consequence of sourcing the config from a Kubernetes secret.  This means that tasks like installing and configuring a plugin is impossible or unnecessarily difficult, as the application has no way to persist config changes (as it cannot write to the read-only filesystem).

This PR introduces a new configuration setting, `persistence.config`, which controls whether or not mattermost will be allowed to update its own configuration.  If `persistence.config.enabled` is set to `true`, then the `configJSON` value will only be respected on initial helm install, and an init container will copy this JSON over to a writable persistent volume, which will then be used by the application.  This will allow the application to write any changes it needs to within the `config.json` file.

The downside of this is that further updates to `configJSON` after the initial install will do nothing.  Users that would prefer to manage their entire JSON config via helm can still do so by setting `persistence.config.enabled` to `false`.

A couple of notes:

- I didn't add documentation for this property, since it appears that `persistence.*` isn't documented.  I'm happy to add documentation for my changes as well as backfill docs for the other persistence variables as well.  I could also write an explicit section in the README about this change if you'd like.
- I set the default value of `persistence.config.enabled` to `true`, as this is the behavior I originally expected when I first used the chart.  I'm happy to update the default to `false` if you'd like.

#### Ticket Link

Fixes #100
