### PR TITLE
Upgrade MM-TE to be helm v3 fully compatible

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
+apiVersion: v2
 description: Mattermost Team Edition server.
+type: application
 name: mattermost-team-edition
-version: 3.22.0
-appVersion: 5.29.0
+version: 4.0.0
+appVersion: 5.32.1
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -12,3 +12,8 @@ icon: http://www.mattermost.org/wp-content/uploads/2016/04/icon.png
 sources:
 - https://github.com/mattermost/mattermost-server
 - https://github.com/mattermost/mattermost-helm
+dependencies:
+- name: mysql
+  version: 1.6.4
+  repository: https://charts.helm.sh/stable
+  condition: mysql.enabled

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -12,8 +12,3 @@ icon: http://www.mattermost.org/wp-content/uploads/2016/04/icon.png
 sources:
 - https://github.com/mattermost/mattermost-server
 - https://github.com/mattermost/mattermost-helm
-maintainers:
-  - name: cpanato
-    email: carlos@mattermost.com
-  - name: jwilander
-    email: joram@mattermost.com

--- a/charts/mattermost-team-edition/OWNERS
+++ b/charts/mattermost-team-edition/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- cpanato
-- jwilander
-reviewers:
-- cpanato
-- jwilander

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -28,11 +28,11 @@ cluster using the [Helm](https://helm.sh) package manager.
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/mattermost-team-edition
+$ helm install --name my-release mattermost/mattermost-team-edition
 ```
  **Helm v3 command**
 ```bash
-$ helm install my-release stable/mattermost-team-edition
+$ helm install my-release mattermost/mattermost-team-edition
 ```
 
 The command deploys Mattermost on the Kubernetes cluster in the default configuration. The [configuration](#configuration)
@@ -45,6 +45,10 @@ method of resolving them is to simply upgrade the chart and let it fail with and
 provide you with a custom message on what you need to change in your
 configuration. Note that this failure will occur before any changes have been
 made to the k8s cluster.
+
+## Upgrading  the Chart to 4.0.0+
+
+The Chart version 4.0.0+ supports only Helm v3, follow the [guide](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/)
 
 ## Uninstalling the Chart
 

--- a/charts/mattermost-team-edition/requirements.lock
+++ b/charts/mattermost-team-edition/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: https://charts.helm.sh/stable
-  version: 1.6.4
-digest: sha256:01345d74dd8069b6c142c7c52e67ea41ede74613386426f7217e14efcc65a1b3
-generated: "2021-01-28T10:10:11.382320093-05:00"

--- a/charts/mattermost-team-edition/requirements.yaml
+++ b/charts/mattermost-team-edition/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- name: mysql
-  version: 1.6.4
-  repository: https://charts.helm.sh/stable
-  condition: mysql.enabled

--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -4,3 +4,4 @@ chart-repos:
   - incubator=https://charts.helm.sh/incubator
   - stable=https://charts.helm.sh/stable
 helm-extra-args: --timeout 5m0s
+validate-maintainers: false


### PR DESCRIPTION
#### Summary
Helm 2 is deprecated, and we should not support more this version, at this stage whoever is using it should have already migrated from v2 to v3.
This PR update the chart to the helm v3 way 😄 

- Remove the owners names, because this was set up when this chart was in the helm/charts repo, not needed here for now
- update the dependencies file to the helm v3 pattern
- update the ct config to ignore the maintainers in the chart.yaml file
- bump MM-TE to the latest version

tested with a previous chart version and upgraded to these changes and no issues found during the upgrade.

after this will do the  same for the other charts too


cc @stylianosrigas @khos2ow @angeloskyratzakos 

#### Ticket Link

NONE
