### PR TITLE
Fix Mattermost 5.30+ startup issue caused by read only config.json

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 4.0.0
+version: 4.0.1
 appVersion: 5.32.1
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -3,7 +3,7 @@ description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
 version: 4.0.1
-appVersion: 5.32.1
+appVersion: 5.33.0
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -50,6 +50,16 @@ spec:
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
         command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
       {{- end }}
+      - name: "init-copy-config-json"
+        image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+        imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
+        command: [ "sh", "-c", "cp /tmp/config.json /tmp/config/config.json && chmod go+rw /tmp/config/config.json" ]
+        volumeMounts:
+          - mountPath: /tmp/config.json
+            name: config-json
+            subPath: config.json
+          - mountPath: /tmp/config
+            name: mattermost-config
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}
       {{- end }}
@@ -80,9 +90,8 @@ spec:
             path: /api/v4/system/ping
             port: http
         volumeMounts:
-        - mountPath: /mattermost/config/config.json
-          name: config-json
-          subPath: config.json
+        - mountPath: /mattermost/config
+          name: mattermost-config
         - mountPath: /mattermost/data
           name: mattermost-data
         - mountPath: /mattermost/{{ trimPrefix "./" .Values.configJSON.PluginSettings.Directory }}
@@ -99,6 +108,8 @@ spec:
       - name: config-json
         secret:
           secretName: {{ include "mattermost-team-edition.fullname" . }}-config-json
+      - name: mattermost-config
+        emptyDir: {}
       - name: mattermost-data
       {{ if .Values.persistence.data.enabled }}
         persistentVolumeClaim:

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 5.29.0
+  tag: 5.33.0
   imagePullPolicy: IfNotPresent
 
 initContainerImage:


### PR DESCRIPTION
#### Summary
This PR will copy the config.json from the k8s secret, which is of course read only, to a k8s emptyDir via a initContainer.
Then the matermost container can use the config.json from the emptyDir. The config must be writeable since Mattermost 5.30+ because Mattermost will pretty-print the config.json since this version.

In my opinion, this PR is a better option than #208 becaus you will always get a reproduceable container at startup and you can enforce/change stuff via infrastructure-as-code. And it should be 100% compatible with older versions and you don't need a new PVC

#### Ticket Link
This PR will fix #203

