### PR TITLE
Deployment Strategy

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 5.1.0
+version: 5.1.1
 appVersion: 5.36.1
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -9,9 +9,7 @@ metadata:
     helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
 spec:
   replicas: 1
-  strategy:
-    type: RollingUpdate
-    rollingUpdate: null
+  strategy: {{ toYaml .Values.deploymentStrategy | nindent 4 }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -11,6 +11,12 @@ initContainerImage:
   tag: latest
   imagePullPolicy: IfNotPresent
 
+## Deployment Strategy
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate: null
+
 ## How many old ReplicaSets for Mattermost Deployment you want to retain
 revisionHistoryLimit: 1
 


### PR DESCRIPTION
#### Summary

Helm Upgrade might fail with `RollingUpdate` if the new pod gets into another node, introduce new config called  `deploymentStrategy` to enable customization while keeping full Backwards Compability

