### PR TITLE
Add securityContext for enterprise-edition chart

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.14.0
+version: 1.15.0
 appVersion: 5.33.3
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -49,11 +49,13 @@ spec:
       tolerations:
         {{ toYaml .Values.mattermostApp.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.mattermostApp.securityContext }}
       securityContext:
         {{- toYaml .Values.mattermostApp.securityContext | nindent 8 }}
-      {{ if .Values.serviceAccount.create }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
-      {{ end }}
+      {{- end }}
       initContainers:
       {{- if .Values.global.features.elasticsearch.enabled }}
       - name: init-elasticsearch

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -49,6 +49,8 @@ spec:
       tolerations:
         {{ toYaml .Values.mattermostApp.tolerations | indent 8 }}
       {{- end }}
+      securityContext:
+        {{- toYaml .Values.mattermostApp.securityContext | nindent 8 }}
       {{ if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{ end }}

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -47,6 +47,10 @@ spec:
       tolerations:
         {{ toYaml .Values.global.features.jobserver.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.mattermostApp.securityContext }}
+      securityContext:
+        {{- toYaml .Values.mattermostApp.securityContext | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: "init-mattermost-app"
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -177,6 +177,13 @@ mattermostApp:
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
+  ## Pod Security Context
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext:
+    fsGroup: 2000
+    runAsGroup: 2000
+    runAsUser: 2000
+
   resources: {}
     # limits:
     #   cpu: 100m

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -180,9 +180,9 @@ mattermostApp:
   ## Pod Security Context
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
-    fsGroup: 2000
-    runAsGroup: 2000
-    runAsUser: 2000
+    # fsGroup: 2000
+    # runAsGroup: 2000
+    # runAsUser: 2000
 
   resources: {}
     # limits:


### PR DESCRIPTION
All credit goes to @mrparkers 

This PR adds changes from #208 to enterprise-edition chart only. Copy-pasting the relevant PR description from #208 below.

----

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR allows users to configure the application pod's security context, which is required in order to persist changes to the filesystem for plugins and user data.
<!--
A description of what this pull request does.
-->

#### Ticket Link

Fixes #203

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
