### PR TITLE
[GH-239] Add support for service account and security context in teams chart

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 5.2.1
+version: 5.3.1
 appVersion: 5.37.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -149,6 +149,9 @@ Parameter                             | Description                             
 `service.annotations`                 | Service annotations                                                                             | `{}`
 `service.loadBalancerIP`              | A user-specified IP address for service type LoadBalancer to use as External IP (if supported)  | `nil`
 `service.loadBalancerSourceRanges`    | list of IP CIDRs allowed access to load balancer (if supported)                                 | `[]`
+`serviceAccount.create`               | Enables creation and use of a service account for the mattermost pod                            | `false`
+`serviceAccount.name`                 | Name of the service account to create and use                                                   | ""
+`serviceAccount.annotations`          | The service account annotations                                                                 | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -41,6 +41,13 @@ spec:
       tolerations:
         {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       initContainers:
       {{- if not .Values.externalDB.enabled }}
       - name: "init-mysql"

--- a/charts/mattermost-team-edition/templates/service-account.yaml
+++ b/charts/mattermost-team-edition/templates/service-account.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ tpl (toYaml .Values.serviceAccount.annotations) . | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "mattermost-team-edition.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
+{{ end }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -200,6 +200,18 @@ affinity: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod Security Context
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  # fsGroup: 2000
+  # runAsGroup: 2000
+  # runAsUser: 2000
+
+serviceAccount:
+  create: false
+  name:
+  annotations: {}
+
 ## Configuration
 ## The config here will be injected as environment variables in the deployment
 ## Please refer to https://docs.mattermost.com/administration/config-settings.html#configuration-in-database for more information


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The mattermost team chart does not allow to specify a service account
which makes impossible to use s3 with the IAM role on the service
account.

Also added the securityContext block since it may be required on EKS
prior to 1.19
(https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-helm/issues/239

