### PR TITLE
[MM-EE]: Add support for Ingress networking.k8s.io/v1 apiVersion

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
-version: 1.18.0
+version: 1.19.0
 appVersion: 5.38.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/_helpers.tpl
+++ b/charts/mattermost-enterprise-edition/templates/_helpers.tpl
@@ -49,8 +49,10 @@ Return the appropriate apiVersion for ingress. Based on
 {{- define "mattermost-enterprise-edition.ingress.apiVersion" -}}
 {{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 "extensions/v1beta1"
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0, <1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 "networking.k8s.io/v1beta1"
+{{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1"
 {{- end -}}
 {{- end -}}
 

--- a/charts/mattermost-enterprise-edition/templates/ingress-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/ingress-mattermost-app.yaml
@@ -22,6 +22,20 @@ metadata:
     {{- end }}
 spec:
   rules:
+  {{- if eq (include "mattermost-enterprise-edition.ingress.apiVersion" .) "\"networking.k8s.io/v1\"" }}
+  {{- range $host := .Values.mattermostApp.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service: 
+            name: {{ $serviceName }}
+            port:
+              number: {{ $servicePort }}
+  {{- end -}}
+  {{- else }}
   {{- range $host := .Values.mattermostApp.ingress.hosts }}
   - host: {{ $host }}
     http:
@@ -30,6 +44,7 @@ spec:
         backend:
           serviceName: {{ $serviceName }}
           servicePort: {{ $servicePort }}
+  {{- end -}}
   {{- end -}}
   {{- if .Values.mattermostApp.ingress.tls }}
   tls:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds support for the newest Ingress apiVersion (`networking.k8s.io/v1`). Older apiVersions are now deprecated, and starting in k8s 1.22 this apiVersion is the only one available. This PR maintains backwards compatibility with the `extensions/v1beta1` and `networking.k8s.io/v1beta1` apiVersions.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://github.com/mattermost/mattermost-helm/issues/249