### PR TITLE
Feature/private registry

### DIFF
--- a/charts/mattermost-operator/Chart.yaml
+++ b/charts/mattermost-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-operator
 description: A Helm chart for Mattermost Operator
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.16.0
 keywords:
 - operator

--- a/charts/mattermost-operator/templates/mattermost-operator/deployment.yaml
+++ b/charts/mattermost-operator/templates/mattermost-operator/deployment.yaml
@@ -43,4 +43,8 @@ spec:
         imagePullPolicy: "{{ .Values.mattermostOperator.image.pullPolicy }}"
         name: {{ template "mattermost-operator.name" . }}
       serviceAccountName: {{ template "mattermost-operator.name" . }}
+      {{- if .Values.mattermostOperator.privateRegistry.enabled }}
+      imagePullSecrets:
+        - name: {{ .Values.mattermostOperator.privateRegistry.imagePullSecret}}
+      {{- end}}
 {{- end }}

--- a/charts/mattermost-operator/values.yaml
+++ b/charts/mattermost-operator/values.yaml
@@ -19,6 +19,12 @@ mattermostOperator:
   args:
     - --enable-leader-election
 
+  ## Specify image pull secret for private repository
+  ##
+  privateRegistry:
+    enabled: false
+    imagePullSecret: <name of the secret>
+
 ### IMPORTANT: Below operators should be deployed separately in production environments. ###
 minioOperator:
   enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

PR makes it possible to pull operator images from a private registry, when needing to authenticate. 
Added additional field to supply a Secret name where the Registry Credentials are located in the namespace. 

Documentation needs to be clarified a bit I think to make sure people don't make mistakes. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-helm/issues/233
