### PR TITLE
Do not pass Chart version to deployment selectors

### DIFF
--- a/charts/mattermost-operator/Chart.yaml
+++ b/charts/mattermost-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-operator
 description: A Helm chart for Mattermost Operator
 type: application
-version: 0.2.2
+version: 0.3.0
 appVersion: 1.16.0
 keywords:
 - operator

--- a/charts/mattermost-operator/templates/mattermost-operator/deployment.yaml
+++ b/charts/mattermost-operator/templates/mattermost-operator/deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       name: {{ template "mattermost-operator.name" . }}
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/name: {{ template "mattermost-operator.name" . }}
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mattermost-operator/templates/minio-operator/deployment.yaml
+++ b/charts/mattermost-operator/templates/minio-operator/deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       name: {{ template "minio-operator.name" . }}
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/name: {{ template "minio-operator.name" . }}
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mattermost-operator/templates/mysql-operator/statefulset.yaml
+++ b/charts/mattermost-operator/templates/mysql-operator/statefulset.yaml
@@ -17,7 +17,6 @@ spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/name: {{ template "mysql-operator.name" . }}
       app.kubernetes.io/managed-by: {{ .Release.Service }}
       app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Currently, the Chart version is passed to the value of one of the selector labels.
The selector, however, is immutable therefore any bump to the chart version makes it impossible to upgrade the chart with `helm upgrade`.

This PR removes the` helm.sh/chart` label from selector to fix this issue.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-41087

