### PR TITLE
Mattermost Teams Add support for Ingress networking.k8s.io/v1 apiVersion

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.3.0
+version: 6.4.0
 appVersion: 6.3.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -108,6 +108,18 @@ $ helm upgrade  mm-te -f custom_values.yaml mattermost/mattermost-team-edition
 
 If in your `custom_values.yaml` you set the image.tag, please update that to the latest available, at the time of this doc was write the version is `5.35.3`
 
+## Kubernetes 1.22 Ingress
+
+When updating to Kubernetes 1.22 ensure chart version `6.4.0`+ has been run in the environment prior to the kuberentes update.
+If a chart less than `6.4.0`  the `Ingress` api version will not be updated.
+`Ingress` has been removed from `networking.k8s.io/v1beta1` as of kubernetes 1.22 and has been moved to `networking.k8s.io/v1`
+If when on Kubernetes 1.22 this error is seen:
+```
+Error: UPGRADE FAILED: current release manifest contains removed kubernetes api(s) for this kubernetes version...
+```
+follow steps here to resolve the `Ingress` version mismatch
+https://helm.sh/docs/topics/kubernetes_apis/
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:

--- a/charts/mattermost-team-edition/templates/_helpers.tpl
+++ b/charts/mattermost-team-edition/templates/_helpers.tpl
@@ -39,7 +39,9 @@ Return the appropriate apiVersion for ingress. Based on
 {{- define "mattermost-team-edition.ingress.apiVersion" -}}
 {{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 "extensions/v1beta1"
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0, <1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 "networking.k8s.io/v1beta1"
+{{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1"
 {{- end -}}
 {{- end -}}

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -23,6 +23,20 @@ metadata:
     {{- end }}
 spec:
   rules:
+  {{- if eq (include "mattermost-team-edition.ingress.apiVersion" .) "\"networking.k8s.io/v1\"" }}
+  {{- range $host := $ingress.hosts }}
+  - host: {{ $host | quote }}
+    http:
+      paths:
+      - path: {{ $ingress.path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $servicePort }}
+  {{- end -}}
+  {{- else }}
   {{ range $host := $ingress.hosts }}
   - host: {{ $host | quote }}
     http:
@@ -32,8 +46,10 @@ spec:
           serviceName: {{ $serviceName }}
           servicePort: {{ $servicePort }}
   {{ end }}
+  {{ end }}
   {{ if $ingress.tls }}
   tls:
     {{- $ingress.tls | toYaml | nindent 4 }}
   {{ end }}
 {{ end }}
+


### PR DESCRIPTION
Add support for  Ingress `networking.k8s.io/v1` for mattermost teams chart.
` Ingress networking.k8s.io/v1` will only be used for kuberentes 1.19+ and old versions will maintain their current functionality.

Added instructions to readme for how to recover if the update to kubernetes 1.22 is done before running this chart update as the ` Ingress networking.k8s.io/v1beta1` is removed in this version.
