### PR TITLE
add extraEnv to jobserver values for libpq PG* variables

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.4.4
+version: 2.4.5
 appVersion: 6.5.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -76,6 +76,9 @@ spec:
               name: {{ include "mattermost-enterprise-edition.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret
            {{- end }}
+{{- with .Values.global.features.jobserver.extraEnv }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         volumeMounts:
         {{- if .Values.global.existingLicenseSecret.name }}
         - mountPath: /mattermost/{{.Values.global.existingLicenseSecret.key }}

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -76,9 +76,9 @@ spec:
               name: {{ include "mattermost-enterprise-edition.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret
            {{- end }}
-{{- with .Values.global.features.jobserver.extraEnv }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+           {{- with .Values.global.features.jobserver.extraEnv }}
+           {{- toYaml . | indent 8 }}
+           {{- end }}
         volumeMounts:
         {{- if .Values.global.existingLicenseSecret.name }}
         - mountPath: /mattermost/{{.Values.global.existingLicenseSecret.key }}

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -64,6 +64,8 @@ global:
       # jobserver Tolerations for pod assignment
       # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
       tolerations: []
+      # Allows the specification of additional environment variables for Mattermost Jobserver
+      extraEnv: {}
     notifications:
       # Push proxy must be configured or useHPNS must be true for push noticiations to work.
       push:


### PR DESCRIPTION
#### Summary

This PR adds `extraEnv` array to the jobserver configuration in order to set various environment variables for mattermost.

In short, when using an external postgres, with `driverName: postgres`, you can leave datasource as an empty string, and use `extraEnv` to pass [libpq environment variables](https://www.postgresql.org/docs/current/libpq-envars.html) to the mattermost process.  Some of these can be pulled from secrets.

#### Ticket Link

This PR partially addresses [#140](https://github.com/mattermost/mattermost-helm/issues/140), when using an external postgresql database.

#### Values example

When using mattermost paired with [Postgres Operator](https://postgres-operator.readthedocs.io/en/latest/)

```yaml
extraEnv:
  - name: PGHOST
    value: mattermost-database.mattermost.svc.cluster.local
  - name: PGPORT
    value: "5432"
  - name: PGDATABASE
    value: mattermost
  - name: MM_LDAPSETTINGS_BINDUSERNAME
    valueFrom:
      secretKeyRef:
        key: dn
        name: ldap-credentials
  - name: MM_LDAPSETTINGS_BINDPASSWORD
    valueFrom:
      secretKeyRef:
        key: password
        name: ldap-credentials
  - name: PGUSER
    valueFrom:
      secretKeyRef:
        key: username
        name: mattermost.mattermost-database.credentials.postgresql.acid.zalan.do
  - name: PGPASSWORD
    valueFrom:
      secretKeyRef:
        key: password
        name: mattermost.mattermost-database.credentials.postgresql.acid.zalan.do
```
