### PR TITLE
[GH-280] Add support for networking.k8s.io/v1 ingress

### DIFF
--- a/charts/focalboard/Chart.yaml
+++ b/charts/focalboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: focalboard
 description: Focalboard Server
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "0.6.7"
 keywords:
   - focalboard

--- a/charts/focalboard/templates/ingress.yaml
+++ b/charts/focalboard/templates/ingress.yaml
@@ -35,14 +35,14 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
             pathType: Prefix
-            {{- else -}}
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}

--- a/charts/focalboard/templates/ingress.yaml
+++ b/charts/focalboard/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "focalboard.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -33,9 +35,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: Prefix
+            {{- else -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/mattermost-chaos-engine/Chart.yaml
+++ b/charts/mattermost-chaos-engine/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0

--- a/charts/mattermost-chaos-engine/templates/ingress.yaml
+++ b/charts/mattermost-chaos-engine/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mattermost-chaos-engine.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -33,9 +35,18 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: Prefix
+            {{- else -}}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.4.5
+version: 2.5.0
 appVersion: 6.5.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/charts/mattermost-grafana/templates/ingress.yaml
+++ b/charts/mattermost-enterprise-edition/charts/mattermost-grafana/templates/ingress.yaml
@@ -22,9 +22,18 @@ spec:
       http:
         paths:
           - path: /
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            backend:
+              service:
+                name: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
+                port:
+                  number: {{ $servicePort }}
+            pathType: Prefix
+            {{- else -}}
             backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
               servicePort: {{ $servicePort }}
+            {{- else -}}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/charts/mattermost-enterprise-edition/charts/mattermost-grafana/templates/ingress.yaml
+++ b/charts/mattermost-enterprise-edition/charts/mattermost-grafana/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
             backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
               servicePort: {{ $servicePort }}
-            {{- else -}}
+            {{- end -}}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/charts/mattermost-enterprise-edition/templates/_helpers.tpl
+++ b/charts/mattermost-enterprise-edition/templates/_helpers.tpl
@@ -47,10 +47,12 @@ Return the appropriate apiVersion for ingress. Based on
 2) Kubernetes Version
 */}}
 {{- define "mattermost-enterprise-edition.ingress.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-"extensions/v1beta1"
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+"networking.k8s.io/v1"
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 "networking.k8s.io/v1beta1"
+{{- else -}}
+"extensions/v1beta1"
 {{- end -}}
 {{- end -}}
 

--- a/charts/mattermost-enterprise-edition/templates/ingress-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/ingress-mattermost-app.yaml
@@ -30,9 +30,18 @@ spec:
     http:
       paths:
       - path: /
+        {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        backend:
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $servicePort }}
+        pathType: Prefix
+        {{- else }}
         backend:
           serviceName: {{ $serviceName }}
           servicePort: {{ $servicePort }}
+        {{- end }}
   {{- end -}}
   {{- if .Values.mattermostApp.ingress.tls }}
   tls:

--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.6.4
+version: 0.7.0
 appVersion: 5.22.5
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/templates/_helpers.tpl
+++ b/charts/mattermost-push-proxy/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Create chart name and version as used by the chart label.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "mattermost-push-proxy.ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
       {{- print "networking.k8s.io/v1" -}}
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
     {{- print "networking.k8s.io/v1beta1" -}}

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.5.0
+version: 6.6.0
 appVersion: 6.5.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/_helpers.tpl
+++ b/charts/mattermost-team-edition/templates/_helpers.tpl
@@ -37,9 +37,11 @@ Return the appropriate apiVersion for ingress. Based on
 2) Kubernetes Version
 */}}
 {{- define "mattermost-team-edition.ingress.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-"extensions/v1beta1"
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+"networking.k8s.io/v1"
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 "networking.k8s.io/v1beta1"
+{{- else -}}
+"extensions/v1beta1"
 {{- end -}}
 {{- end -}}

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -28,9 +28,18 @@ spec:
     http:
       paths:
       - path: {{ $ingress.path }}
+        {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        backend:
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $servicePort }}
+        pathType: Prefix
+        {{- else }}
         backend:
           serviceName: {{ $serviceName }}
           servicePort: {{ $servicePort }}
+        {{- end }}
   {{ end }}
   {{ if $ingress.tls }}
   tls:


### PR DESCRIPTION
#### Summary
This PR adds support for [networking.k8s.io/v1](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122) Ingress objects while retaining support for unserved `networking.k8s.io/v1beta1` and `extensions/v1beta1` Ingress objects as well.

Out of neccessity, it also adds support for Helm v3 while retaining support for Helm v2. While [Helm v2 does support](https://v2.helm.sh/docs/chart_template_guide/#built-in-objects) the `.Capabilities.KubeVersion.GitVersion` object, [Helm v3 does not support it](https://v2.helm.sh/docs/chart_template_guide/#built-in-objects), and only supports `.Capabilities.KubeVersion.Version`. Rather sifting through Helm versions and Kubernetes versions to identify support, supported API versions are validated using `.Capabilities.APIVersions.Has` which is supported by Helm v2 and v3.

This has only been tested to a limited extent since I wanted to get this up; if there is a good chance of this being merged, I would be happy to do some further testing.

#### Ticket Link
Fixes [mattermost-helm#280](https://github.com/mattermost/mattermost-helm/issues/280)
