### PR TITLE
Bump team edition helm chart to v6.6.0

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.0
-appVersion: 6.5.0
+version: 6.6.1
+appVersion: 6.6.0
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 6.5.0@sha256:4ef7dd898559ca1f7edf2ca0b3f44cf26aeff813f9e9b8c815bebf226db796e0
+  tag: 6.6.0@sha256:9fe89a7a1dc60f627fac7f0b8ce1cb0a08e0a9ab0d144ea97316da250205d9e3
   imagePullPolicy: IfNotPresent
 
 initContainerImage:


### PR DESCRIPTION
Issue: DOPS-936

Summary
Bump team edition helm chart to v6.6.0

Ticket Link
https://mattermost.atlassian.net/browse/DOPS-936