### PR TITLE
Bump enterprise helm chart to v6.6.0 

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.5.0
-appVersion: 6.5.0
+version: 2.6.0
+appVersion: 6.6.0
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -125,7 +125,7 @@ mattermostApp:
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
-    tag: 6.5.0@sha256:8fe1709cdbe9840243fc82a8c7648c4a3d0612434a1b1b06e963c96f821a6f84
+    tag: 6.6.0@sha256:1040906f5fb9be28f55b88563c42238f3db7f61d47e12c14cd260e8cf827236f
     pullPolicy: IfNotPresent
 
   strategy:


### PR DESCRIPTION
Issue: DOPS-936

Summary
Bump enterprise helm chart to v6.6.0

Ticket Link
https://mattermost.atlassian.net/browse/DOPS-936