### PR TITLE
[GH-326] [GH-327] Add tests to detect templating errors in more common situations and fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,19 @@ jobs:
 
   lint-charts:
     docker:
-      - image: quay.io/helmpack/chart-testing:v3.4.0
+      - image: quay.io/helmpack/chart-testing:v3.5.1
     steps:
       - checkout
       - run:
           command: ct lint --config tests/ct.yaml
+
+  validate-charts:
+    docker:
+      - image: quay.io/helmpack/chart-testing:v3.5.1
+    steps:
+      - checkout
+      - run:
+          command: tests/validate-charts.sh
 
   install-charts:
     machine: true

--- a/charts/focalboard/Chart.yaml
+++ b/charts/focalboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: focalboard
 description: Focalboard Server
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.6.7"
 keywords:
   - focalboard

--- a/charts/focalboard/templates/ingress.yaml
+++ b/charts/focalboard/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-            pathType: Prefix
+            pathType: ImplementationSpecific
             {{- else }}
             backend:
               serviceName: {{ $fullName }}

--- a/charts/mattermost-chaos-engine/Chart.yaml
+++ b/charts/mattermost-chaos-engine/Chart.yaml
@@ -11,4 +11,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/charts/mattermost-chaos-engine/templates/ingress.yaml
+++ b/charts/mattermost-chaos-engine/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mattermost-chaos-engine.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -35,14 +35,14 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-            pathType: Prefix
-            {{- else -}}
+            pathType: ImplementationSpecific
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}

--- a/charts/mattermost-enterprise-edition/Chart.lock
+++ b/charts/mattermost-enterprise-edition/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: mattermost-elasticsearch
+  repository: ""
+  version: 0.1.0
+- name: mattermost-grafana
+  repository: ""
+  version: 0.3.6
+- name: mysqlha
+  repository: https://charts.helm.sh/incubator
+  version: 2.0.0
+- name: minio
+  repository: https://charts.helm.sh/stable
+  version: 5.0.26
+- name: prometheus
+  repository: https://charts.helm.sh/stable
+  version: 11.4.0
+digest: sha256:fa90782b768ec2654b9763569f86aab463052b1877feff8a05e5b04e364c5582
+generated: "2022-04-14T09:56:29.688029-04:00"

--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.5.0
+version: 2.5.1
 appVersion: 6.5.0
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/charts/mattermost-grafana/templates/ingress.yaml
+++ b/charts/mattermost-enterprise-edition/charts/mattermost-grafana/templates/ingress.yaml
@@ -22,18 +22,18 @@ spec:
       http:
         paths:
           - path: /
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             backend:
               service:
                 name: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
                 port:
                   number: {{ $servicePort }}
-            pathType: Prefix
-            {{- else -}}
+            pathType: ImplementationSpecific
+            {{- else }}
             backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
               servicePort: {{ $servicePort }}
-            {{- end -}}
+            {{- end }}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 5.22.5
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/templates/ingress.yaml
+++ b/charts/mattermost-push-proxy/templates/ingress.yaml
@@ -38,19 +38,18 @@ spec:
         paths:
         {{- range .paths }}
         - path: {{ .path }}
-          {{- if $ingressSupportsPathType }}
-          pathType: {{ default "ImplementationSpecific" .pathType }}
-          {{- end }}
+          {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
           backend:
-            {{- if $ingressApiIsStable }}
             service:
               name: {{ $serviceName }}
               port:
                 number: {{ $servicePort }}
-            {{- else }}
+          pathType: ImplementationSpecific
+          {{- else }}
+          backend:
             serviceName: {{ $serviceName }}
             servicePort: {{ $servicePort }}
-            {{- end }}
+          {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mattermost-team-edition/Chart.lock
+++ b/charts/mattermost-team-edition/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mysql
+  repository: https://charts.helm.sh/stable
+  version: 1.6.4
+digest: sha256:01345d74dd8069b6c142c7c52e67ea41ede74613386426f7217e14efcc65a1b3
+generated: "2022-04-14T09:56:56.670061-04:00"

--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.0
+version: 6.6.1
 appVersion: 6.5.0
 keywords:
 - mattermost

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             name: {{ $serviceName }}
             port:
               number: {{ $servicePort }}
-        pathType: Prefix
+        pathType: ImplementationSpecific
         {{- else }}
         backend:
           serviceName: {{ $serviceName }}

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v3.4.0
+readonly CT_VERSION=v3.5.1
 readonly KIND_VERSION=v0.11.1
 readonly CLUSTER_NAME=mattermost-helm-test
 

--- a/tests/validate-charts.sh
+++ b/tests/validate-charts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+################################################################################
+# This script executed the `helm template` command on all shart defined in the 
+# `./charts` directory. It enables common features for all templates, such as
+# ingress and persistence.
+#
+# This is neccessary since `chart-testing` does not catch templating errors
+# even when the new `helm-extra-set-args` values are defined.
+#
+# STDOUT is redirected to null to keep the logs clean, and only errors will be
+# displayed.
+################################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+for CHART_YAML in charts/**/Chart.yaml
+do
+  CHART_DIR="$(dirname "${CHART_YAML}")"
+
+  helm template "${CHART_DIR}" \
+    --values "${CHART_DIR}/values.yaml" \
+    --set=ingress.enabled=true \
+    --set=presistence.enabled=true \
+    --set=autoscaling.enabled=true > /dev/null
+done


### PR DESCRIPTION
#### Summary
This PR adds tests to help identify templating errors by running `helm template` silently, and failing on errors. This also allows sensible default values to be defined (e.g. `ingress.enabled=true`, `presistence.enabled=true` and `autoscaling.enabled=true`) for more comprehensive coverage.

I attempted to implement this by using the latest version of [chart-testing](https://github.com/helm/chart-testing), however, the configuration options don't appear to work, and it could not effectively identify errors without supplying new `values.yaml` files.

This PR also fixes ingress template errors in the `mattermost-chaos-engine` and `mattermost-grafana` chart recently introduced by #322.

#### Ticket Link
Fixes #326 and #327

