### PR TITLE
fix-extraEnv-default-value

### DIFF
--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -65,7 +65,7 @@ global:
       # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
       tolerations: []
       # Allows the specification of additional environment variables for Mattermost Jobserver
-      extraEnv: {}
+      extraEnv: []
     notifications:
       # Push proxy must be configured or useHPNS must be true for push noticiations to work.
       push:


### PR DESCRIPTION
#### Summary
I messed up the default value for extraEnv in #316. This fixes the jobserver.extraEnv to be an array, which is what the template is expecting

Without this change, if trying to use jobserver's extraEnvs, you get this error:

```
cannot overwrite table with non table for mattermost-enterprise-edition.global.features.jobserver.extraEnv
```
