### PR TITLE
Bump mattermost enterprise version to 6.6.1

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.6.0
-appVersion: 6.6.0
+version: 2.6.1
+appVersion: 6.6.1
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -125,7 +125,7 @@ mattermostApp:
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
-    tag: 6.6.0@sha256:1040906f5fb9be28f55b88563c42238f3db7f61d47e12c14cd260e8cf827236f
+    tag: 6.6.1@sha256:90cce607ffa0f1453c77b386675a5265a2fa93663c794820866286c82149f107
     pullPolicy: IfNotPresent
 
   strategy:


### PR DESCRIPTION
Summary
Bump version for Mattermost Enterprise to 6.6.1

Ticket Link
Ticket: https://mattermost.atlassian.net/browse/DOPS-763