### PR TITLE
Bump Mattermost Team Edition Version to 6.6.1

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.1
-appVersion: 6.6.0
+version: 6.6.2
+appVersion: 6.6.1
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 6.6.0@sha256:9fe89a7a1dc60f627fac7f0b8ce1cb0a08e0a9ab0d144ea97316da250205d9e3
+  tag: 6.6.1@sha256:dd663d96bf3d63f8081b971aae8a1b0800ce497c303d1800f8a23d7b87419b8e
   imagePullPolicy: IfNotPresent
 
 initContainerImage:


### PR DESCRIPTION
Summary
Bump version for Mattermost Team to 6.6.1

Ticket Link
Ticket: https://mattermost.atlassian.net/browse/DOPS-978