### PR TITLE
fix: using nintend for extraEnvs on JobServer

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.6.6
+version: 2.6.7
 appVersion: 7.0.1
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -76,9 +76,9 @@ spec:
               name: {{ include "mattermost-enterprise-edition.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret
            {{- end }}
-           {{- with .Values.global.features.jobserver.extraEnv }}
-           {{- toYaml . | indent 8 }}
-           {{- end }}
+        {{- with .Values.global.features.jobserver.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.global.existingLicenseSecret.name }}
         - mountPath: /mattermost/{{.Values.global.existingLicenseSecret.key }}


### PR DESCRIPTION
#### Summary
Fixing an issue where resulting intention would be wrong on `jobserver.extraEnv`.   
Problem is that all lines before have `-` which results in the first line of `extraEnv` is moved behind `MM_CONFIG.valueFrom.secretKeyRef.key`, resulting in a yaml error. Using `nintend` fixes this issue.