### PR TITLE
Migrate CircleCI PR pipelines to Github Actions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,5 @@
 version: 2.1
 jobs:
-  lint-scripts:
-    docker:
-      - image: koalaman/shellcheck-alpine
-    steps:
-      - checkout
-      - run:
-          command: |
-            shellcheck -x tests/e2e-kind.sh
-            shellcheck -x .circleci/install_tools.sh
-            shellcheck -x .circleci/release.sh
-
-  lint-charts:
-    docker:
-      - image: quay.io/helmpack/chart-testing:v3.4.0
-    steps:
-      - checkout
-      - run:
-          command: ct lint --config tests/ct.yaml
-
-  install-charts:
-    machine: true
-    steps:
-      - checkout
-      - run:
-          command: tests/e2e-kind.sh
-          no_output_timeout: 1h
-
   release-charts:
     machine: true
     steps:
@@ -43,14 +16,6 @@ jobs:
 
 workflows:
   version: 2
-  untagged-build:
-    jobs:
-      - lint-scripts
-      - lint-charts
-      - install-charts:
-          requires:
-            - lint-scripts
-            - lint-charts
   release:
     jobs:
       - release-charts:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,34 @@
+name: "Validate PR"
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    name: Lint Project
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout everything since ct uses git diff to determine charts
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+        with:
+          fetch-depth: 0 
+      - name: Execute Lint
+        run: make lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+    steps:
+      # Checkout everything since ct uses git diff to determine charts
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+        with:
+          fetch-depth: 0 
+      - name: Execute Tests
+        run: make test
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ tags
 charts/mattermost-enterprise-edition/charts/*.tgz
 charts/mattermost-team-edition/charts/*.tgz
 
-vscode/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,51 @@
-.PHONY: install clean package ltvalues
+DOCKER := $(shell which docker)
+DOCKER_OPTS += --rm -u $$(id -u):$$(id -g)
+CLUSTER_NAME ?= mattermost-helm-test
 
-DIST_ROOT=dist
-KUBE_INSTALL := $(shell command -v kubectl 2> /dev/null)
-HELM_INSTALL := $(shell command -v helm 2> /dev/null)
+DOCKER_IMAGE_SHELLCHECK ?= koalaman/shellcheck:v0.8.0@sha256:4c4427336d2b4bdb054a1e97396fa2e9ca0c329a1f43f831b99bcaae4ac24fcd
+# Official image of chart-testing[https://github.com/helm/chart-testing].
+# Contains chart-testing cli,  helm and kubectl.
+DOCKER_IMAGE_CT ?= quay.io/helmpack/chart-testing:v3.7.0@sha256:2f87e56a0cebc6d9bb78d51cb6adac97858afb0887cac4d65f7f8c6a16054568
 
-SUB_CHARTS := $(shell ls mattermost-helm/charts)
+VERIFY_SCRIPTS += /src/tests/e2e-kind.sh
 
-all: package
+CT_CONFIG ?= tests/ct.yaml
+KIND_CONFIG ?= tests/kind-config.yaml
+CLUSTER_NAME ?= mattermost-helm-test
 
-check:
-ifndef KUBE_INSTALL
-    $(error "kubectl is not available please install from https://kubernetes.io/")
-endif
-ifndef HELM_INSTALL
-    $(error "helm is not available please install from https://github.com/kubernetes/helm")
-endif
+ .PHONY: lint
+ lint: lint-scripts lint-charts ## Lint helm charts and shell scripts
 
-.init:
-	helm init --client-only
-	touch $@
+ .PHONY: lint-charts
+lint-charts: ## Validate helm charts
+	$(DOCKER) run \
+		${DOCKER_OPTS} \
+		-v $(PWD):/src \
+		-w /src \
+		--entrypoint '/bin/sh' \
+		${DOCKER_IMAGE_CT} \
+		-c \
+		"ls >/dev/null && ct lint --config tests/ct.yaml"
 
-package: check .init
-	# Temporary while we wait for changes to be merged upstream
-	helm repo add mattermost-mysqlha https://releases.mattermost.com/helm/mysqlha
-	mkdir -p dist
-	rm -f mattermost-helm/charts/*.tgz
-	helm package mattermost-helm/charts/* -d mattermost-helm/charts
-	helm dep up mattermost-helm
-	helm package mattermost-helm -d $(DIST_ROOT)
+.PHONY: lint-scripts
+lint-scripts: ## Validate shell scripts
+	$(DOCKER) run \
+		${DOCKER_OPTS} \
+		-v $(PWD):/src \
+		-w /src \
+		${DOCKER_IMAGE_SHELLCHECK} \
+		$(VERIFY_SCRIPTS)
 
-clean:
-	rm -rf $(DIST_ROOT)
-	rm -f mattermost-helm/charts/*.tgz
+.PHONY: test
+test: ## Execute e2e tests on changed charts
+	 DOCKER_IMAGE_CT="$(DOCKER_IMAGE_CT)" \
+	 CLUSTER_NAME="$(CLUSTER_NAME)" \
+	 CT_CONFIG="$(CT_CONFIG)" \
+	 KIND_CONFIG="$(KIND_CONFIG)" \
+	 	tests/e2e-kind.sh
 
-install: check
-	helm install dist/mattermost-helm*.*
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-ltvalues:
-	cp ../platform-private/kubernetes/values_loadtest.yaml mattermost-helm/values.yaml
+

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ This repository collects a set of [Helm](https://helm.sh) charts curated by [Mat
 
 Click on the following links to see installation instructions for each chart:
 
-- [mattermost-team-edition](charts/mattermost-team-edition/)
+- [focalboard](charts/focalboard/)
+- [mattermost-chaos-engine](charts/mattermost-chaos-engine/)
 - [mattermost-enterprise-edition](charts/mattermost-enterprise-edition/)
-- [mattermost-push-proxy](charts/mattermost-push-proxy/)
 - [mattermost-operator](charts/mattermost-operator/)
+- [mattermost-push-proxy](charts/mattermost-push-proxy/)
+- [mattermost-rtcd](charts/mattermost-rtcd/)
+- [mattermost-team-edition](charts/mattermost-team-edition/)
 
 ## Usage
 
@@ -25,3 +28,27 @@ $ helm repo add mattermost https://helm.mattermost.com
 
 We welcome contributions.
 Please refer to our [contribution guidelines](CONTRIBUTING.md) for details.
+
+## Local Development
+
+### Requirements
+
+1. Install [GNU make](https://www.gnu.org/software/make/).
+2. Install [Docker](https://docs.docker.com/engine/install/).
+3. Install [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+### Verify Changes
+
+To verify changes and execute lint, please execute below command:
+
+```
+make lint
+```
+
+### Testing
+
+To execute chart tests locally, please execute below command:
+
+```
+make test
+```

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -1,78 +1,37 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v3.4.0
-readonly KIND_VERSION=v0.11.1
-readonly CLUSTER_NAME=mattermost-helm-test
+changed=$( docker run --rm -u "$(id -u):$(id -g)" \
+        --entrypoint '/bin/sh' \
+        -v "$(pwd):/src" \
+        -w /src \
+        "${DOCKER_IMAGE_CT}" \
+        -c \
+        "ls > /dev/null && ct list-changed --config ${CT_CONFIG}")
+    
+		
+if [[ -z "$changed" ]]; then
+    echo 'No chart changes detected.'
+    exit 0
+fi
 
-run_ct_container() {
-    echo 'Running ct container...'
-    docker run --rm --interactive --detach --network host --name ct \
-        --volume "$(pwd)/tests/ct.yaml:/etc/ct/ct.yaml" \
-        --volume "$(pwd):/workdir" \
-        --workdir /workdir \
-        "quay.io/helmpack/chart-testing:$CT_VERSION" \
-        cat
-    echo
-}
+echo "Chart changes detected.Changed Charts:"
+echo "${changed}"
 
-cleanup() {
-    echo 'Removing ct container...'
-    docker kill ct > /dev/null 2>&1
+cluster_name=$(kind get clusters | grep "${CLUSTER_NAME:-N/A}" || echo "N/A")
 
-    echo 'Done!'
-}
+if [[ "$cluster_name" != "${CLUSTER_NAME}" ]]; then
+    kind create cluster --name "$CLUSTER_NAME" --config "${KIND_CONFIG}" --wait 120s
+fi
 
-docker_exec() {
-    docker exec --interactive ct "$@"
-}
-
-create_kind_cluster() {
-    echo 'Installing kind...'
-
-    curl -sSLo kind "https://github.com/kubernetes-sigs/kind/releases/download/$KIND_VERSION/kind-linux-amd64"
-    chmod +x kind
-    sudo mv kind /usr/local/bin/kind
-
-    kind create cluster --name "$CLUSTER_NAME" --config tests/kind-config.yaml --wait 60s
-
-    docker_exec mkdir -p /root/.kube
-
-    echo 'Copying kubeconfig to container...'
-
-    docker cp "$HOME/.kube/config" ct:/root/.kube/config
-
-    docker_exec kubectl cluster-info
-    echo
-
-    docker_exec kubectl get nodes
-    echo
-
-    echo 'Cluster ready!'
-    echo
-}
-
-install_charts() {
-    docker_exec ct install
-    echo
-}
-
-main() {
-    run_ct_container
-    trap cleanup EXIT
-
-    changed=$(docker_exec ct list-changed)
-    if [[ -z "$changed" ]]; then
-        echo 'No chart changes detected.'
-        return
-    fi
-
-    echo 'Chart changes detected.'
-    create_kind_cluster
-    install_charts
-}
-
-main
+docker run --rm -u "$(id -u):$(id -g)" --interactive --network host \
+    -entrypoint '/bin/sh' \
+    -v "$HOME/.kube/config:/root/.kube/config" \
+    -v "$(pwd):/src" \
+    -w /src \
+    "${DOCKER_IMAGE_CT}" \
+    -c \
+    "ls > /dev/null && ct install --config ${CT_CONFIG}"


### PR DESCRIPTION
#### Summary
We will move CircleCI pipelines to Github Actions to fix race condition. Since we stop supporting CircleCI, we are migrating existing pipelines to Github Actions.

This PR contains migration of pull request pipelines, after having stable pipelines here, we will migrate release pipelines and fix race condition at followup PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3709
