### PR TITLE
docs: remove misleading config option

### DIFF
--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -124,7 +124,6 @@ The following table lists the configurable parameters of the Mattermost Team Edi
 
 Parameter                             | Description                                                                                     | Default
 ---                                   | ---                                                                                             | ---
-`configJSON`                          | The `config.json` configuration to be used by the mattermost server. The values you provide will by using Helm's merging behavior override individual default values only. See the [example configuration](#example-configuration) and the [Mattermost documentation](https://docs.mattermost.com/administration/config-settings.html) for details. |  See `configJSON` in [values.yaml](https://github.com/helm/charts/blob/master/stable/mattermost-team-edition/values.yaml)
 `image.repository`                    | Container image repository                                                                      | `mattermost/mattermost-team-edition`
 `image.tag`                           | Container image tag                                                                             | `5.39.0`
 `image.imagePullPolicy`               | Container image pull policy                                                                     | `IfNotPresent`


### PR DESCRIPTION
#### Summary

The option `configJSON` was deprecated by https://github.com/mattermost/mattermost-helm/pull/225. Since it is not used in the source anymore (except `charts/mattermost-team-edition/templates/_deprecations.tpl`), it makes no sense to keep it.

#### Ticket Link

N/A

