### PR TITLE
Simplify release script and skip existing releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ main() {
 
     for chart in charts/*; do
         echo "Packaging chart '$chart'..."
-        package_chart $chart
+        package_chart "$chart"
     done
     release_charts
     sleep 30


### PR DESCRIPTION
#### Summary
We simplified the script and utilising better the `chart-releaser` CLI. Now we iterate through all charts and we package them but we will upload only the packages are new. Added a new flag for `chart-releaser` which will help us to skip the existing packages.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3970


