### PR TITLE
add installation config of CR, provide examples

### DIFF
--- a/charts/mattermost-operator/Chart.yaml
+++ b/charts/mattermost-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-operator
 description: A Helm chart for Mattermost Operator
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.18.0
 keywords:
 - operator

--- a/charts/mattermost-operator/templates/mattermost-operator/mattermost.yaml
+++ b/charts/mattermost-operator/templates/mattermost-operator/mattermost.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.mattermostCR.enabled }}
+apiVersion: installation.mattermost.com/v1beta1
+kind: Mattermost
+metadata:
+  creationTimestamp: null
+  name: {{ .Values.mattermostCR.name }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ template "mattermost-operator.name" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+{{ toYaml .Values.mattermostCR.spec | indent 2}}
+{{- end }}

--- a/charts/mattermost-operator/values.yaml
+++ b/charts/mattermost-operator/values.yaml
@@ -2,6 +2,38 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# The values beloew are for the mattermost custom resource
+# Full spec example can be found here: https://github.com/mattermost/mattermost-operator/blob/master/docs/examples/mattermost_full.yaml
+# Examples for mattermost spec can be found here: https://github.com/mattermost/mattermost-operator/tree/master/docs/examples
+# Enable the database, file storage operatorManaged below to run with in cluster database and file storage (not recommended for production scenario).
+mattermostCR:
+  enabled: true
+  name: mattermost-example
+  spec:
+    version: 7.2.0
+    replicas: 1
+    ingress:
+      enabled: true
+      host: example.mattermost-example.com
+    # database:
+    #   operatorManaged:                            # Operator managed database allows configuration of replicas, storage size and resource requirements. If the `size` is specified, it will override those values.
+    #     replicas: 1
+    #     resources:
+    #       requests:
+    #         cpu: 250m
+    #         memory: 512Mi
+    #     storageSize: 50Gi
+    #     type: mysql
+    # fileStore:
+    #   operatorManaged:                            # Operator managed file store allows configuration of replicas, storage size and resource requirements. If the `size` is specified, it will override those values.
+    #     replicas: 1
+    #     resources:
+    #       requests:
+    #         cpu: 150m
+    #         memory: 512Mi
+    #     storageSize: 50Gi
+
+# The values below are for the mattermost operator
 mattermostOperator:
   enabled: true
   replicas: 1

--- a/charts/mattermost-operator/values.yaml
+++ b/charts/mattermost-operator/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# The values beloew are for the mattermost custom resource
+# The values below are for mattermost Custom Resource
 # Full spec example can be found here: https://github.com/mattermost/mattermost-operator/blob/master/docs/examples/mattermost_full.yaml
 # Examples for mattermost spec can be found here: https://github.com/mattermost/mattermost-operator/tree/master/docs/examples
 # Enable the database, file storage operatorManaged below to run with in cluster database and file storage (not recommended for production scenario).

--- a/charts/mattermost-operator/values.yaml
+++ b/charts/mattermost-operator/values.yaml
@@ -7,7 +7,7 @@
 # Examples for mattermost spec can be found here: https://github.com/mattermost/mattermost-operator/tree/master/docs/examples
 # Enable the database, file storage operatorManaged below to run with in cluster database and file storage (not recommended for production scenario).
 mattermostCR:
-  enabled: true
+  enabled: false
   name: mattermost-example
   spec:
     version: 7.2.0

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -28,7 +28,7 @@ if [[ "$cluster_name" != "${CLUSTER_NAME}" ]]; then
 fi
 
 docker run --rm -u "$(id -u):$(id -g)" --interactive --network host \
-    -entrypoint '/bin/sh' \
+    --entrypoint '/bin/sh' \
     -v "$HOME/.kube/config:/root/.kube/config" \
     -v "$(pwd):/src" \
     -w /src \


### PR DESCRIPTION
#### Summary
This adds the option to enable the user the installation of the mattermost CR. instead of looking for examples at the operator
also provided link where the user can view the full spec to take example
