### PR TITLE
Updating config options as ENVs in README, updating a few other links

### DIFF
--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -124,7 +124,7 @@ The following table lists the configurable parameters of the Mattermost Team Edi
 
 Parameter                             | Description                                                                                     | Default
 ---                                   | ---                                                                                             | ---
-`configJSON`                          | The `config.json` configuration to be used by the mattermost server. The values you provide will by using Helm's merging behavior override individual default values only. See the [example configuration](#example-configuration) and the [Mattermost documentation](https://docs.mattermost.com/administration/config-settings.html) for details. |  See `configJSON` in [values.yaml](https://github.com/helm/charts/blob/master/stable/mattermost-team-edition/values.yaml)
+`configJSON`                          | The `config.json` configuration to be used by the mattermost server. The values you provide will by using Helm's merging behavior override individual default values only. See the [example configuration](#example-configuration) and the [Mattermost documentation](https://docs.mattermost.com/configure/configuration-settings.html) for details. |  See `configJSON` in [values.yaml](https://github.com/helm/charts/blob/master/stable/mattermost-team-edition/values.yaml)
 `image.repository`                    | Container image repository                                                                      | `mattermost/mattermost-team-edition`
 `image.tag`                           | Container image tag                                                                             | `5.39.0`
 `image.imagePullPolicy`               | Container image pull policy                                                                     | `IfNotPresent`
@@ -180,11 +180,9 @@ ingress:
   hosts:
     - mattermost.example.com
 
-configJSON:
-  ServiceSettings:
-    SiteURL: "https://mattermost.example.com"
-  TeamSettings:
-    SiteName: "Mattermost on Example.com"
+config:
+  MM_SERVICESETTINGS_SITEURL: "https://mattermost.example.com"
+  MM_TEAMSETTINGS_SITENAME: "Mattermost on Example.com"
 ```
 
 ### External Databases

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -214,7 +214,7 @@ serviceAccount:
 
 ## Configuration
 ## The config here will be injected as environment variables in the deployment
-## Please refer to https://docs.mattermost.com/administration/config-settings.html#configuration-in-database for more information
+## Please refer to https://docs.mattermost.com/configure/configuration-settings.html#configuration-in-database for more information
 ## You can add any config here, but need to respect the format: MM_<GROUPSECTION>_<SETTING>. ie: MM_SERVICESETTINGS_ENABLECOMMANDS: false
 config:
   MM_PLUGINSETTINGS_CLIENTDIRECTORY: "./client/plugins"


### PR DESCRIPTION
Signed-off-by: garcia.ryan <garcia.ryan@solute.us>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Updating section of README for mattermost team edition to use `config` values with ENV vars rather than `configJSON` items per issue #238 . Also updating a few other broken links.


#### Ticket Link

  Fixes #238 


