### PR TITLE
Feature/secret

### DIFF
--- a/charts/mattermost-rtcd/Chart.yaml
+++ b/charts/mattermost-rtcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-rtcd
 description: A Helm chart for Kubernetes to deploy Mattermost's RTCD
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: latest
 keywords:
 - mattermost

--- a/charts/mattermost-rtcd/templates/daemonset.yaml
+++ b/charts/mattermost-rtcd/templates/daemonset.yaml
@@ -23,9 +23,9 @@ spec:
       labels:
         {{- include "mattermost-rtcd.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+    {{- if .Values.privateRegistry.enabled }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        - name: {{ .Values.privateRegistry.imagePullSecret }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true

--- a/charts/mattermost-rtcd/values.yaml
+++ b/charts/mattermost-rtcd/values.yaml
@@ -8,7 +8,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
+  ## Specify image pull secret for private repository
+  ##
+privateRegistry:
+  enabled: false
+  imagePullSecret: <name of the secret>
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This adds the ability to specify a registry secret similar to the mattermost-operator helm chart. I was having issues with specifying the registry secret, this PR makes it more clear in the helm-values.yaml. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Could this be included with the `hacktoberfest` label? 