### PR TITLE
allow to disable the creation of the database credentials secret

### DIFF
--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -63,11 +63,13 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         env:
+        {{- if .Values.externalDB.generateSecretWithConnectionString }}
         - name: MM_CONFIG
           valueFrom:
             secretKeyRef:
               name: {{ include "mattermost-team-edition.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret
+        {{- end }}
         {{- if .Values.extraEnvVars }}
           {{- .Values.extraEnvVars | toYaml | nindent 8 }}
         {{- end }}

--- a/charts/mattermost-team-edition/templates/secret-mattermost-dbsecret.yaml
+++ b/charts/mattermost-team-edition/templates/secret-mattermost-dbsecret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.externalDB.generateSecretWithConnectionString }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ data:
   mattermost.dbsecret: {{ tpl  "mysql://{{ .Values.mysql.mysqlUser }}:{{ .Values.mysql.mysqlPassword }}@tcp({{ .Release.Name }}-mysql:3306)/{{ .Values.mysql.mysqlDatabase }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" . | b64enc }}
 {{- else }}
   mattermost.dbsecret: {{ tpl "{{ .Values.externalDB.externalDriverType }}://{{ .Values.externalDB.externalConnectionString }}" . | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -94,6 +94,10 @@ externalDB:
   ## mysql:     "<USERNAME>:<PASSWORD>@tcp(<HOST>:3306)/<DATABASE_NAME>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
   externalConnectionString: ""
 
+  # Create the secret with the externalConnectionString
+  # If False you must supply the connection details with the env var MM_CONFIG (see extraEnvVars doc for an example)
+  generateSecretWithConnectionString: true
+
 mysql:
   enabled: true
   mysqlRootPassword: ""
@@ -144,6 +148,20 @@ extraEnvVars: []
   #   value: "postgres"
   # - name: MM_SQLSETTINGS_DATASOURCE
   #   value: postgres://$(POSTGRES_USER_GITLAB):$(POSTGRES_PASSWORD_GITLAB)@$(POSTGRES_HOST_GITLAB):$(POSTGRES_PORT_GITLAB)/$(POSTGRES_DB_NAME_MATTERMOST)?sslmode=disable&connect_timeout=10
+
+  # This an example of extra env vars when setting externalDB.generateSecretWithConnectionString to false and using the credentials created by the Zalando PostgreSQL Operator
+  # - name: MATTERMOST_DB_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: password
+  #       name: DATABASE.DATABASE_CLUSTER.credentials.postgresql.acid.zalan.do
+  # - name: MATTERMOST_DB_USERNAME
+  #   valueFrom:
+  #     secretKeyRef:
+  #       key: username
+  #       name: DATABASE.DATABASE_CLUSTER.credentials.postgresql.acid.zalan.do
+  # - name: MM_CONFIG
+  #   value: "postgres://$(MATTERMOST_DB_USERNAME):$(MATTERMOST_DB_PASSWORD)@DATABASE_SERVICE:5432/DATABASE?sslmode=require&connect_timeout=10"
 
 ## Additional init containers
 extraInitContainers: []


### PR DESCRIPTION
This PR allows to disable the creation of the secret with the ConnectionString for a external Database.

Why:

We are using the Postgres Operator from Zalando and want to use the generated Secrets of the operator. At the moment this is a manual process, because it is not possible to fill the variable MM_CONFIG with the data from the secret. And it is not possible to overwrite the variable with extraEnvVars.