### PR TITLE
#387 Support imagePullSecrets in mattermost-enterprise-edition

### DIFF
--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -193,3 +193,8 @@ spec:
 {{- if .Values.mattermostApp.extraVolumes }}
 {{ toYaml .Values.mattermostApp.extraVolumes | indent 6 }}
 {{- end }}
+      {{- with .Values.mattermostApp.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -97,5 +97,8 @@ spec:
           {{- else }}
           secretName: {{ include "mattermost-enterprise-edition.fullname" . }}-mattermost-license
           {{- end }}
-
+      {{- with .Values.mattermostApp.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end -}}

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-loadtest.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-loadtest.yaml
@@ -87,4 +87,8 @@ spec:
             items:
             - key: loadtestconfig.json
               path: loadtestconfig.json
+      {{- with .Values.mattermostApp.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
#### Summary
`imagePullSecrets` needs in `mattermost-enterprise-edition` helm chart for more convenience as below.
```yaml
    spec:
      container:
      ...
      {{- with .Values.mattermostApp.image.imagePullSecrets }}
      imagePullSecrets:
        {{- toYaml . | nindent 8 }}
      {{- end }}
```
thus it edited three parts of templates,
- deployment-mattermost-app.yaml
- deployment-mattermost-jobserver.yaml
- deployment-mattermost-loadtest.yaml

and it referred to the [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret).
 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-helm/issues/387

