### PR TITLE
Run CI/CD on master branch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,16 +2,18 @@ name: "Validate PR"
 
 on:
   pull_request:
-    branches: [ master ]
+  push:
+    branches:
+    - master
 
 jobs:
   lint:
     name: Lint Project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Checkout everything since ct uses git diff to determine charts
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:
           fetch-depth: 0 
       - name: Execute Lint
@@ -19,16 +21,14 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - lint
     steps:
       # Checkout everything since ct uses git diff to determine charts
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
         with:
           fetch-depth: 0 
       - name: Execute Tests
         run: make test
-
-


### PR DESCRIPTION
This change updates some github action imports and runs the normal CI/CD checks on the master branch.
