### PR TITLE
Bump Operator and Mattermost default versions

### DIFF
--- a/charts/mattermost-operator/Chart.yaml
+++ b/charts/mattermost-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: mattermost-operator
 description: A Helm chart for Mattermost Operator
 type: application
 version: 0.3.4
-appVersion: 1.20.0
+appVersion: 1.20.1
 keywords:
 - operator
 - mattermost

--- a/charts/mattermost-operator/Chart.yaml
+++ b/charts/mattermost-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-operator
 description: A Helm chart for Mattermost Operator
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: 1.20.1
 keywords:
 - operator

--- a/charts/mattermost-operator/values.yaml
+++ b/charts/mattermost-operator/values.yaml
@@ -10,7 +10,7 @@ mattermostCR:
   enabled: false
   name: mattermost-example
   spec:
-    version: 7.9.1
+    version: 7.10.2
     replicas: 1
     ingress:
       enabled: true
@@ -47,7 +47,7 @@ mattermostOperator:
     requeuOnLimitDelay: 20s
   image:
     repository: mattermost/mattermost-operator
-    tag: v1.20.0
+    tag: v1.20.1
     pullPolicy: IfNotPresent
   args:
     - --enable-leader-election


### PR DESCRIPTION
Operator updated to v1.20.1
Optional Mattermost deployment version updated to v7.10.2
