### PR TITLE
[MM-53140] Allow TCP connectivity for Calls

### DIFF
--- a/charts/mattermost-rtcd/Chart.yaml
+++ b/charts/mattermost-rtcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-rtcd
 description: A Helm chart for Kubernetes to deploy Mattermost's RTCD
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: latest
 keywords:
 - mattermost

--- a/charts/mattermost-rtcd/Chart.yaml
+++ b/charts/mattermost-rtcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-rtcd
 description: A Helm chart for Kubernetes to deploy Mattermost's RTCD
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: latest
 keywords:
 - mattermost

--- a/charts/mattermost-rtcd/templates/daemonset.yaml
+++ b/charts/mattermost-rtcd/templates/daemonset.yaml
@@ -55,10 +55,14 @@ spec:
               containerPort: {{ .Values.service.APIport }}
               hostPort: {{ .Values.service.APIport }}
               protocol: TCP              
-            - name: rtc
+            - name: rtc-udp
               containerPort: {{ .Values.service.RTCport }}
               hostPort: {{ .Values.service.RTCport }}
               protocol: UDP
+            - name: rtc-tcp
+              containerPort: {{ .Values.service.RTCport }}
+              hostPort: {{ .Values.service.RTCport }}
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /version

--- a/charts/mattermost-rtcd/templates/deployment.yaml
+++ b/charts/mattermost-rtcd/templates/deployment.yaml
@@ -56,10 +56,14 @@ spec:
               containerPort: {{ .Values.service.APIport }}
               hostPort: {{ .Values.service.APIport }}
               protocol: TCP              
-            - name: rtc
+            - name: rtc-udp
               containerPort: {{ .Values.service.RTCport }}
               hostPort: {{ .Values.service.RTCport }}
               protocol: UDP
+            - name: rtc-tcp
+              containerPort: {{ .Values.service.RTCport }}
+              hostPort: {{ .Values.service.RTCport }}
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /version

--- a/charts/mattermost-rtcd/templates/service.yaml
+++ b/charts/mattermost-rtcd/templates/service.yaml
@@ -12,8 +12,12 @@ spec:
       protocol: TCP
       name: api
     - port: {{ .Values.service.RTCport }}
-      targetPort: rtc
+      targetPort: rtc-udp
       protocol: UDP
-      name: rtc
+      name: rtc-udp
+    - port: {{ .Values.service.RTCport }}
+      targetPort: rtc-tcp
+      protocol: TCP
+      name: rtc-tcp
   selector:
     {{- include "mattermost-rtcd.selectorLabels" . | nindent 4 }}

--- a/charts/mattermost-rtcd/values.yaml
+++ b/charts/mattermost-rtcd/values.yaml
@@ -44,8 +44,11 @@ configuration:
   environmentVariables: {}
     # All env vars that exist for RTCD: https://github.com/mattermost/rtcd/blob/master/docs/env_config.md
     # RTCD_API_SECURITY_ALLOWSELFREGISTRATION: "\"true\""
+    # RTCD_RTC_ICESERVERS: "'[{\"urls\":[\"stun:stun.global.calls.mattermost.com:3478\"]}]'"
     # RTCD_LOGGER_CONSOLELEVEL: "\"DEBUG\""
     # RTCD_LOGGER_ENABLEFILE: "\"false\""
+    # RTCD_RTC_ICEPORTUDP: "\"8443\""
+    # RTCD_RTC_ICEPORTTCP: "\"8443\""
 
   maxUnavailable: 1     # Only used when updateStrategy is set to "RollingUpdate"
   updateStrategy: RollingUpdate
@@ -64,7 +67,7 @@ configuration:
 service:
   # APIport is the port that websocket and API uses
   APIport: 8045
-  # RTCport is the UDP port that RTC uses
+  # RTCport is the port (both UDP and TCP) that will serve calls related traffic (i.e. audio,video)
   RTCport: 8443
 
 ingress:


### PR DESCRIPTION
#### Summary

We are introducing support for TCP candidates for calls in https://github.com/mattermost/rtcd/pull/103. This means that if no UDP connection is possible, a TCP channel can be used instead as a backup option. The big advantage of this approach is that it can avoid having to deploy and maintain a separate TURN server to guarantee connectivity for clients unable to use UDP for whatever reason (e.g. protocol blocked by firewall).

I am updating the helm chart to reflect the changes although I couldn't really understand whether most of these are actually used/needed given we use host networking. Looking for SREs input on this.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53140
