### PR TITLE
Added startupProbe

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.30
+version: 6.6.31
 appVersion: 7.10.4
 keywords:
   - mattermost

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -83,17 +83,15 @@ spec:
           containerPort: {{ .port }}
           protocol: {{ .protocol }}
         {{- end }}
-        livenessProbe:
-          initialDelaySeconds: 90
-          timeoutSeconds: 5
-          periodSeconds: 15
+        startupProbe: {{- .Values.startupProbe | toYaml | nindent 10 }}
+          httpGet:
+            path: /healthz
+            port: http
+        livenessProbe: {{- .Values.livenessProbe | toYaml | nindent 10 }}
           httpGet:
             path: /api/v4/system/ping
             port: http
-        readinessProbe:
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-          periodSeconds: 15
+        readinessProbe: {{- .Values.readinessProbe | toYaml | nindent 10 }}
           httpGet:
             path: /api/v4/system/ping
             port: http

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -225,3 +225,22 @@ serviceAccount:
 ## You can add any config here, but need to respect the format: MM_<GROUPSECTION>_<SETTING>. ie: MM_SERVICESETTINGS_ENABLECOMMANDS: false
 config:
   MM_PLUGINSETTINGS_CLIENTDIRECTORY: "./client/plugins"
+
+## Configure startup, liveness and readiness probes
+startupProbe:
+  initialDelaySeconds: 10
+  failureThreshold: 30
+  timeoutSeconds: 5
+  periodSeconds: 10
+
+livenessProbe:
+  initialDelaySeconds: 1
+  failureThreshold: 3
+  timeoutSeconds: 5
+  periodSeconds: 10
+
+readinessProbe:
+  initialDelaySeconds: 15
+  failureThreshold: 3
+  timeoutSeconds: 5
+  periodSeconds: 10


### PR DESCRIPTION
Added startupProbe 

- to increase start speed up.
- best practice
- some migrations can takes a long time and initialDelaySeconds=90 for livenessProbe maybe a little.
