### PR TITLE
[MM-49202] Add retention time for failed calls-offloader jobs

### DIFF
--- a/charts/mattermost-calls-offloader/Chart.yaml
+++ b/charts/mattermost-calls-offloader/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mattermost-calls-offloader
 description: A Helm chart for Kubernetes to deploy Mattermost's Calls Offloader service
 type: application
-version: 0.1.2
-appVersion: "0.3.3"
+version: 0.1.3
+appVersion: "0.4.0"
 keywords:
 - mattermost
 - calls-offloader

--- a/charts/mattermost-calls-offloader/values.yaml
+++ b/charts/mattermost-calls-offloader/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: mattermost/calls-offloader
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.3"
+  tag: "v0.4.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -77,6 +77,8 @@ config:
     value: "kubernetes"
   - name: JOBS_MAXCONCURRENTJOBS
     value: "1"
+  - name: JOBS_FAILEDJOBSRETENTIONTIME
+    value: "7d"
   - name: API_SECURITY_ALLOWSELFREGISTRATION # This should only be set to true if running the service inside a private network.
     value: "true"
   - name: LOGGER_CONSOLELEVEL


### PR DESCRIPTION
#### Summary

As per related PR, starting in the next version we'll be able to configure a retention time for failed jobs through the `JOBS_FAILEDJOBSRETENTIONTIME` env variable which controls the [`TTLSecondsAfterFinished`](https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/) value of the kubernetes job spec. This should finally remove the need to manually delete every failed recording jobs.

#### Related PR

https://github.com/mattermost/calls-offloader/pull/43

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49202
