### PR TITLE
[MM-54925] Bump calls-offloader to v0.4.1

### DIFF
--- a/charts/mattermost-calls-offloader/Chart.yaml
+++ b/charts/mattermost-calls-offloader/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mattermost-calls-offloader
 description: A Helm chart for Kubernetes to deploy Mattermost's Calls Offloader service
 type: application
-version: 0.1.3
-appVersion: "0.4.0"
+version: 0.1.4
+appVersion: "0.4.1"
 keywords:
 - mattermost
 - calls-offloader

--- a/charts/mattermost-calls-offloader/values.yaml
+++ b/charts/mattermost-calls-offloader/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: mattermost/calls-offloader
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.4.0"
+  tag: "v0.4.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
#### Summary

We [fixed](https://github.com/mattermost/calls-offloader/pull/45) the parsing issue on the `JOBS_FAILEDJOBSRETENTIONTIME` env override and pushed a new dot release.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54925