### PR TITLE
fix: k8s > 1.24 do not support autoscaling/v2beta1

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.6.37
+version: 2.7.0
 appVersion: 9.1.1
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-hpa.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.mattermostApp.autoscaling.enabled }}
+{{- if semverCompare ">= 1.25-0" .Capabilities.KubeVersion.Version }}
 apiVersion: autoscaling/v2
+{{ else }}
+apiVersion: autoscaling/v2beta1
+{{ end }}
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-hpa.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.mattermostApp.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:


### PR DESCRIPTION
#### Summary
`autoscaling/v2beta1` is not longer supported in K8S >= 1.25
