### PR TITLE
[CLD-6577] Push proxy support service annotations

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: 5.28.0
 keywords:
 - mattermost
@@ -17,6 +17,8 @@ maintainers:
     email: stylianos.rigas@mattermost.com
   - name: spirosoik
     email: spiros.economakis@mattermost.com
+  - name: delivery-team
+    email: devops@mattermost.com
 sources:
 - https://github.com/mattermost/mattermost-helm
 - https://github.com/mattermost/mattermost-push-proxy

--- a/charts/mattermost-push-proxy/templates/service.yaml
+++ b/charts/mattermost-push-proxy/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart:  {{ include "mattermost-push-proxy.chart" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/mattermost-push-proxy/values.yaml
+++ b/charts/mattermost-push-proxy/values.yaml
@@ -27,6 +27,7 @@ service:
   type: ClusterIP
   externalPort: 8066
   internalPort: 8066
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This enhancement provides optional support for push-proxy chart, Service annotations.

This can be particularly useful in scenarios where `service.type: LoadBalancer` is utilized instead of Ingress, allowing users to configure custom annotations for additional LoadBalancer setup



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-6577
