### PR TITLE
[CLD-6577] Mattermost push-proxy service templating revisit

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.10.2
+version: 0.10.3
 appVersion: 5.28.0
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/templates/service.yaml
+++ b/charts/mattermost-push-proxy/templates/service.yaml
@@ -14,10 +14,30 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.externalPort }}
+  {{- if and .Values.service.externalPort (not (eq .Values.service.type "LoadBalancer")) }}
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
-      name: {{ .Values.service.name }}
+  {{- end }}
+  {{- if and .Values.service.enableHttp (eq .Values.service.type "LoadBalancer") }}
+    - name: {{ .Values.service.name }}-http
+      port: 80
+      protocol: TCP
+      targetPort: {{ .Values.service.internalPort }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) }}
+      appProtocol: http
+    {{- end }}
+  {{- end }}
+  {{- if and .Values.service.enableHttps (eq .Values.service.type "LoadBalancer") }}
+    - name: {{ .Values.service.name }}-https
+      port: 443
+      protocol: TCP
+      targetPort: {{ .Values.service.internalPort }}
+    {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) }}
+      appProtocol: https
+    {{- end }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "mattermost-push-proxy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mattermost-push-proxy/values.yaml
+++ b/charts/mattermost-push-proxy/values.yaml
@@ -27,6 +27,12 @@ service:
   type: ClusterIP
   externalPort: 8066
   internalPort: 8066
+
+  # The following configuration is relevant only when service.type is set to `LoadBalancer`, exposing ports HTTP (80) and HTTPS (443).
+  # This is particularly beneficial in situations where service.type is set to `LoadBalancer` instead of `ClusterIP` and/or using Ingress
+  enableHttp: false
+  enableHttps: false
+
   annotations: {}
 
 ingress:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Revisiting `service` templating for the push-proxy chart.

When service.type is set to `LoadBalancer`, optionally exposing ports HTTP (80) and HTTPS (443).
This is particularly beneficial in situations where `service.type` is set to `LoadBalancer` instead of `ClusterIP` and/or using Ingress


Service Manifest continues to render as expected 
```
> helm template charts/mattermost-push-proxy 
[...]
# Source: mattermost-push-proxy/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-mattermost-push-proxy
  labels:
    app.kubernetes.io/name: mattermost-push-proxy
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart:  mattermost-push-proxy-0.10.3
spec:
  type: ClusterIP
  ports:
    - name: mattermost-push-proxy
      port: 8066
      targetPort: 8066
      protocol: TCP
  selector:
    app.kubernetes.io/name: mattermost-push-proxy
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: server
---
[...]
``` 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-6577
