### PR TITLE
[CLD-7062] Push proxy chart revisit ingress spec

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: 5.28.0
 keywords:
 - mattermost

--- a/charts/mattermost-push-proxy/templates/ingress.yaml
+++ b/charts/mattermost-push-proxy/templates/ingress.yaml
@@ -42,7 +42,9 @@ spec:
           pathType: {{ default "ImplementationSpecific" .pathType }}
           {{- end }}
           backend:
-            {{- if $ingressApiIsStable }}
+            {{- if .customService }}
+            {{- toYaml .customServiceSpec | nindent 12 }}
+            {{- else if $ingressApiIsStable }}
             service:
               name: {{ $serviceName }}
               port:

--- a/charts/mattermost-push-proxy/values.yaml
+++ b/charts/mattermost-push-proxy/values.yaml
@@ -48,6 +48,17 @@ ingress:
           # -- pathType (e.g. ImplementationSpecific, Prefix, .. etc.)
           # pathType: Prefix
 
+        # Example of a CustomService Path, using AWS Load Balancer controller to filter traffic reaching /metrics
+        # Directives `customService` & `customServiceSpec` in use
+        # - path: /metrics
+        #   pathType: Prefix
+        #   customService: true
+        #   customServiceSpec:
+        #     service:
+        #       name: response-403
+        #       port:
+        #         name: use-annotation
+
   tls: []
   #  - secretName: push-proxy-example-tls
   #    hosts:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This covers the case when special ingress spec is needed to manage different http paths.
For example, provides support for the following configuration:

```
          - backend:
              service:
                name: response-403
                port:
                  name: use-annotation
            path: /metrics
            pathType: Prefix
```
In which along with the following Ingress annotation and the use of AWS ALB Controller:
```
    alb.ingress.kubernetes.io/actions.response-403: >
          {"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"403","messageBody":"403 Not Allowed"}}
```
Will result in different handling of specific paths


The template continues to render as usual in case `customService` directive is not in use. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-7062
