### PR TITLE
add support for envFrom on enterprise chart

### DIFF
--- a/charts/mattermost-enterprise-edition/Chart.yaml
+++ b/charts/mattermost-enterprise-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Enterprise server with high availitibity.
 name: mattermost-enterprise-edition
 type: application
-version: 2.6.44
+version: 2.6.45
 appVersion: 9.4.2
 keywords:
 - mattermost

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -143,6 +143,10 @@ spec:
 {{- with .Values.mattermostApp.extraEnv }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+        {{- with .Values.mattermostApp.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         livenessProbe:
           initialDelaySeconds: 90
           timeoutSeconds: 5

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -249,6 +249,8 @@ mattermostApp:
     #   value: "true"
     # - name: MM_SERVICESETTINGS_ENABLECUSTOMEMOJI
     #   value: "true"
+  ## Allows the specification of a configmap or secret to set all key-value pairs as environment variables for Mattermost
+  envFrom: []
   ## Additional pod annotations
   extraPodAnnotations: {}
 # MySQL HA Section. Use this to configure MySQL.


### PR DESCRIPTION
#### Summary

Adds the ability to specify `envFrom` on the enterprise chart, allowing for an easier setup of lots of environment variables for configuration (pulling all k/v pairs in as envs rather than having to add 1 by 1).

#### Ticket Link

None opened but happy to open an issue if this warrants further discussion.