### PR TITLE
feat: Upgrade push proxy version and use default value from Chart.yaml

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.10.7
-appVersion: 5.30.0
+version: 0.11.0
+appVersion: 6.0.0
 keywords:
-- mattermost
-- communication
-- notification
-- messaging
-- team colaboration
+  - mattermost
+  - communication
+  - notification
+  - messaging
+  - team colaboration
 home: https://mattermost.com
 icon: http://www.mattermost.org/wp-content/uploads/2016/04/icon.png
 maintainers:
@@ -20,8 +20,8 @@ maintainers:
   - name: delivery-team
     email: devops@mattermost.com
 sources:
-- https://github.com/mattermost/mattermost-helm
-- https://github.com/mattermost/mattermost-push-proxy
+  - https://github.com/mattermost/mattermost-helm
+  - https://github.com/mattermost/mattermost-push-proxy
 annotations:
   artifacthub.io/images: |
     - name: mattermost-push-proxy

--- a/charts/mattermost-push-proxy/templates/deployment.yaml
+++ b/charts/mattermost-push-proxy/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: {{ include "mattermost-push-proxy.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["--config", "/mattermost-push-proxy/config/config.json"]
           ports:

--- a/charts/mattermost-push-proxy/values.yaml
+++ b/charts/mattermost-push-proxy/values.yaml
@@ -1,10 +1,10 @@
 replicaCount: 1
 image:
   repository: mattermost/mattermost-push-proxy
-  tag: 5.30.0
   pullPolicy: Always
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -38,7 +38,8 @@ service:
 ingress:
   enabled: false
   # ingressClassName: nginx
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Upgrade mattermost push proxy chart to support arm64/amd64 docker images 
- Use default .Chart.AppVersion value for image tag 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-7247
