### PR TITLE
Fixes issue with MM_* vars not accepting boolean

### DIFF
--- a/charts/mattermost-team-edition/templates/secret-config.yaml
+++ b/charts/mattermost-team-edition/templates/secret-config.yaml
@@ -10,5 +10,5 @@ metadata:
 type: Opaque
 data:
   {{- range $key, $val := .Values.config }}
-  {{ $key }}: {{ $val | b64enc }}
+  {{ $key }}: {{ $val | toString | b64enc }}
   {{- end }}


### PR DESCRIPTION
Fixes #238 

### Summary 

This fix allows setting integers and booleans as values for helm parameters. 

### Description

Without this fix, using boolean as a value in any `config.MM_*` helm parameter would result in the following error

```
$ helm template my-setup . --set config.MM_SERVICESETTINGS_ENABLEAPIUSERDELETION="true"
Error: template: mattermost-team-edition/templates/secret-config.yaml:13:24: executing "mattermost-team-edition/templates/secret-config.yaml" at <b64enc>: wrong type for value; expected string; got bool
```

A workaround would be to wrap the quoted boolean in single quotes ie. 

```
--set config.MM_SERVICESETTINGS_ENABLEAPIUSERDELETION='"true"'
```

however this environment variable **would be rejected** by the mattermost server and thus the user API deletion would still be disabled.

