### PR TITLE
Allow probe scheme to be customised for TLS deployments

### DIFF
--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -87,14 +87,17 @@ spec:
           httpGet:
             path: /healthz
             port: http
+            scheme: {{ .Values.probeScheme }}
         livenessProbe: {{- .Values.livenessProbe | toYaml | nindent 10 }}
           httpGet:
             path: /api/v4/system/ping
             port: http
+            scheme: {{ .Values.probeScheme }}
         readinessProbe: {{- .Values.readinessProbe | toYaml | nindent 10 }}
           httpGet:
             path: /api/v4/system/ping
             port: http
+            scheme: {{ .Values.probeScheme }}
         volumeMounts:
         - mountPath: /mattermost/config
           name: mattermost-config

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -230,6 +230,10 @@ config:
   MM_PLUGINSETTINGS_CLIENTDIRECTORY: "./client/plugins"
 
 ## Configure startup, liveness and readiness probes
+
+# Set probeScheme to the default of Plain HTTP - change to HTTPS if the mattermost listener is TLS enabled otherwise the probes fail
+probeScheme: HTTP
+
 startupProbe:
   initialDelaySeconds: 10
   failureThreshold: 30


### PR DESCRIPTION
… HTTP/S termination options for liveness/readiness/startup probes

#### Summary
Adds a configuration option and settings in the deployment to facilitate TLS enabled pods

#### Description
Adds a ```probeScheme``` setting in values.yaml which allows the various probes to be either HTTP or HTTPS

Defaults to plain HTTP

#### Ticket Link
None

