### PR TITLE
[CLD-7443] Allow `rtcd` service to be exposed on a privileged port

### DIFF
--- a/charts/mattermost-rtcd/Chart.yaml
+++ b/charts/mattermost-rtcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mattermost-rtcd
 description: A Helm chart for Kubernetes to deploy Mattermost's RTCD
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: latest
 keywords:
 - mattermost

--- a/charts/mattermost-rtcd/templates/deployment.yaml
+++ b/charts/mattermost-rtcd/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      hostNetwork: false
       serviceAccountName: {{ include "mattermost-rtcd.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.configuration.terminationGracePeriod }}
       securityContext:
@@ -57,11 +57,11 @@ spec:
               hostPort: {{ .Values.service.APIport }}
               protocol: TCP              
             - name: rtc-udp
-              containerPort: {{ .Values.service.RTCport }}
+              containerPort: {{ .Values.service.RTCTargetPort }}
               hostPort: {{ .Values.service.RTCport }}
               protocol: UDP
             - name: rtc-tcp
-              containerPort: {{ .Values.service.RTCport }}
+              containerPort: {{ .Values.service.RTCTargetPort }}
               hostPort: {{ .Values.service.RTCport }}
               protocol: TCP
           livenessProbe:

--- a/charts/mattermost-rtcd/values.yaml
+++ b/charts/mattermost-rtcd/values.yaml
@@ -49,6 +49,7 @@ configuration:
     # RTCD_LOGGER_ENABLEFILE: "\"false\""
     # RTCD_RTC_ICEPORTUDP: "\"8443\""
     # RTCD_RTC_ICEPORTTCP: "\"8443\""
+    # RTCD_RTC_ICEHOSTPORTOVERRIDE: "\"443\""
 
   maxUnavailable: 1     # Only used when updateStrategy is set to "RollingUpdate"
   updateStrategy: RollingUpdate
@@ -69,6 +70,8 @@ service:
   APIport: 8045
   # RTCport is the port (both UDP and TCP) that will serve calls related traffic (i.e. audio,video)
   RTCport: 8443
+  # RTCTargetPort is the port (both UDP and TCP) that the service will be listening on internally (in container).
+  RTCTargetPort: 8443
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### Summary

PR proposes a possible solution to the issue we are facing when trying to have `rtcd` listen on a privileged port (lower than 1024). 

So far we've tested a couple of workarounds (full context at https://hub.mattermost.com/private-core/pl/5ubornsmpfnkuyxnmyixgfpich):

1. Setting the `NET_BIND_SERVICE` capability in the container security context.
2. Setting the `net.ipv4.ip_unprivileged_port_start` sysctl in the pod security context.


Unfortunately, none of the above is working, possibly because the image was meant to be run using an unprivileged user at all times. 

So I was thinking we could avoid the problem altogether by using the k8s service as designed and let it forward the traffic from privileged (node level) to unprivileged (container level). The only caveat is that to do so we'll need to disable host networking.

This is the bit I will need some guidance on because I don't have a full understanding of other potential side effects of doing so (e.g. DNS policy?).

> **Note**
> To make this work properly in our deployment we'll also need some changes coming in v0.15.1 (https://github.com/mattermost/rtcd/pull/140).

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7443