### PR TITLE
feat: add configurable container security 

### DIFF
--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -72,6 +72,10 @@ spec:
       - name: init-mysql
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
+        {{- if .Values.mattermostApp.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.mattermostApp.containerSecurityContext | nindent 10 }}
+        {{- end }}
         command: [
           "sh",
           "-c",
@@ -161,6 +165,10 @@ spec:
           httpGet:
             path: /api/v4/system/ping
             port: {{ .Values.mattermostApp.service.internalPort }}
+        {{- if .Values.mattermostApp.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.mattermostApp.containerSecurityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{- if .Values.global.existingLicenseSecret.name }}
         - mountPath: /mattermost/{{.Values.global.existingLicenseSecret.key }}

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -60,6 +60,10 @@ spec:
           "-c",
           "until curl --max-time 5 http://{{ include "mattermost-enterprise-edition.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.mattermostApp.service.internalPort }}/api/v4/system/ping ; do echo waiting for Mattermost App come up; sleep 5; done; echo init-mattermost-app finished"
         ]
+        {{- if .Values.mattermostApp.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.mattermostApp.containerSecurityContext | nindent 10 }}
+        {{- end }}
       containers:
       - name: {{ include "mattermost-enterprise-edition.name" . }}-jobserver
         image: "{{ .Values.mattermostApp.image.repository }}:{{ .Values.mattermostApp.image.tag }}"
@@ -78,6 +82,10 @@ spec:
            {{- end }}
         {{- with .Values.global.features.jobserver.extraEnv }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.mattermostApp.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.mattermostApp.containerSecurityContext | nindent 10 }}
         {{- end }}
         volumeMounts:
         {{- if .Values.global.existingLicenseSecret.name }}

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -195,6 +195,8 @@ mattermostApp:
     # runAsGroup: 2000
     # runAsUser: 2000
 
+## Container Security Context
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext:
     # runAsNonRoot: true
     # allowPrivilegeEscalation: false

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -195,6 +195,12 @@ mattermostApp:
     # runAsGroup: 2000
     # runAsUser: 2000
 
+  containerSecurityContext:
+    # runAsNonRoot: true
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop: ['ALL']
+
   resources: {}
     # limits:
     #   cpu: 100m

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
         command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+        {{- if .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}
@@ -95,6 +99,10 @@ spec:
           httpGet:
             path: /api/v4/system/ping
             port: http
+        {{- if .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /mattermost/config
           name: mattermost-config

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -217,6 +217,12 @@ securityContext:
   # runAsGroup: 2000
   # runAsUser: 2000
 
+containerSecurityContext:
+  # runAsNonRoot: true
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop: ['ALL']
+
 serviceAccount:
   create: false
   name:

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -217,11 +217,13 @@ securityContext:
   # runAsGroup: 2000
   # runAsUser: 2000
 
+## Container Security Context
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 containerSecurityContext:
-  # runAsNonRoot: true
-  # allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop: ['ALL']
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ['ALL']
 
 serviceAccount:
   create: false

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -220,10 +220,10 @@ securityContext:
 ## Container Security Context
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 containerSecurityContext:
-  runAsNonRoot: true
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop: ['ALL']
+  # runAsNonRoot: true
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop: ['ALL']
 
 serviceAccount:
   create: false


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Hi, this pull request introduces a configuration parameter in the `values.yaml`, that allows to configure the `securityContext` on pod level.

I've implemented this feature, as the pod level `securityContext` does not offer all parameters one can set on the container level. A few examples are `runAsNonRoot`,  `allowPrivilegeEscalation`, `capabilities` or `privileged`.  Especially when you thrive to harden the cluster it is important to restrict also the container especially with `runAsNonRoot`, `allowPrivilegeEscalation` and dropping all capabilities.

In case anything is missing or unclear, feel free to ask me :)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Unfortunately I don't have a JIRA or ticket link, since this issue popped up while trying to harden the mattermost installation based on the helm chart.

