### PR TITLE
[mattermost-team-edition] add existingSecret for externalDB

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.60
+version: 6.6.61
 appVersion: 9.10.1
 keywords:
   - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -141,6 +141,8 @@ Parameter                             | Description                             
 `mysql.mysqlPassword`                 | User Password for Mysql (Required)                                                              | ""
 `mysql.mysqlDatabase`                 | Database name (Required)                                                                        | "mattermost"
 `externalDB.enabled`                  | Enables use of an preconfigured external database server                                        | `false`
+`externalDB.existingSecret`           | Uses an externally configured secret instead of externalDriverType + externalConnectionString   | ""
+`externalDB.existingSecretKey`        | The key in the existingSecret containing the necessary Connection String                        | ""
 `externalDB.externalDriverType`       | `"postgres"` or `"mysql"`                                                                       | ""
 `externalDB.externalConnectionString` | See the section about [external databases](#External-Databases).                                | ""
 `extraPodAnnotations`                 | Extra pod annotations to be used in the deployments                                             | `[]`
@@ -218,6 +220,20 @@ externalDB:
   enabled: true
   externalDriverType: "mysql"
   externalConnectionString: "<USERNAME>:<PASSWORD>@tcp(<HOST>:3306)/<DATABASE_NAME>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+```
+
+#### External Secret
+To use an externally configured secret, You need to set Mattermost **externalDB** config and the **existingSecret**
+
+**IMPORTANT:** Make sure the DB is already created before deploying Mattermost services
+
+Example when using **Percona Operator for PostgreSQL**:
+
+```yaml
+externalDB:
+  enabled: true
+  existingSecret: "mattermost-pguser-mattermost"
+  existingSecretKey: "uri"
 ```
 
 #### Expose extra ports

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -66,8 +66,16 @@ spec:
         - name: MM_CONFIG
           valueFrom:
             secretKeyRef:
+              {{- if .Values.externalDB.existingSecret }}
+              name: {{ .Values.externalDB.existingSecret }}
+              {{- else }}
               name: {{ include "mattermost-team-edition.fullname" . }}-mattermost-dbsecret
+              {{- end }}
+              {{- if .Values.externalDB.existingSecretKey }}
+              key: {{ .Values.externalDB.existingSecretKey }}
+              {{- else }}
               key: mattermost.dbsecret
+              {{- end }}
         {{- if .Values.extraEnvVars }}
           {{- .Values.extraEnvVars | toYaml | nindent 8 }}
         {{- end }}

--- a/charts/mattermost-team-edition/templates/secret-mattermost-dbsecret.yaml
+++ b/charts/mattermost-team-edition/templates/secret-mattermost-dbsecret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.externalDB.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,8 +10,9 @@ metadata:
     helm.sh/chart:  {{ include "mattermost-team-edition.chart" . }}
 type: Opaque
 data:
-{{- if .Values.mysql.enabled }}
+  {{- if .Values.mysql.enabled }}
   mattermost.dbsecret: {{ tpl  "mysql://{{ .Values.mysql.mysqlUser }}:{{ .Values.mysql.mysqlPassword }}@tcp({{ .Release.Name }}-mysql:3306)/{{ .Values.mysql.mysqlDatabase }}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" . | b64enc }}
-{{- else }}
+  {{- else }}
   mattermost.dbsecret: {{ tpl "{{ .Values.externalDB.externalDriverType }}://{{ .Values.externalDB.externalConnectionString }}" . | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -88,6 +88,10 @@ route:
 externalDB:
   enabled: false
 
+  ## when externally configured
+  # existingSecret: secretname
+  # existingSecretKey: keywithfulluri
+
   ## postgres or mysql
   externalDriverType: ""
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change adds support for externally managed database secrets, allowing separate encryption or automatic rotation.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-helm/issues/456
Fixes https://github.com/mattermost/mattermost-helm/issues/392

Partially addresses https://github.com/mattermost/mattermost-helm/issues/140

Related to https://github.com/mattermost/mattermost-helm/issues/425, things are implemented differently in `mattermost-enterprise-edition`, I consider this approach more reliable.