### PR TITLE
Fix apple_auth_key definition in common-secret

### DIFF
--- a/charts/mattermost-push-proxy/Chart.yaml
+++ b/charts/mattermost-push-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Push Proxy server
 name: mattermost-push-proxy
 type: application
-version: 0.12.3
+version: 0.12.4
 appVersion: 6.1.0
 keywords:
   - mattermost

--- a/charts/mattermost-push-proxy/templates/deployment.yaml
+++ b/charts/mattermost-push-proxy/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
           secret:
             secretName: {{ include "mattermost-push-proxy.fullname" . }}-secret
             items:
-              - key: "auth-key-file"
+              - key: "apple_auth_key"
                 path: "auth-key-file"
               - key: "apple_cert"
                 path: "apple-push-cert.pem"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix apple_auth_key definition in common-secret



