### PR TITLE
Allow you to set pod labels

### DIFF
--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-app.yaml
@@ -31,6 +31,9 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: server
         helm.sh/chart: {{ include "mattermost-enterprise-edition.chart" . }}
+        {{- if .Values.extraPodLabels }}
+        {{- .Values.extraPodLabels | toYaml | nindent 8 }}
+        {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.mattermostApp.service.metricsPort }}"

--- a/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost-enterprise-edition/templates/deployment-mattermost-jobserver.yaml
@@ -30,6 +30,9 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: {{ .Values.global.features.jobserver.name }}
         helm.sh/chart: {{ include "mattermost-enterprise-edition.chart" . }}
+        {{- if .Values.extraPodLabels }}
+        {{- .Values.extraPodLabels | toYaml | nindent 8 }}
+        {{- end }}
       annotations:
         {{- if .Values.mattermostApp.extraPodAnnotations }}
         {{- .Values.mattermostApp.extraPodAnnotations | toYaml | nindent 8 }}

--- a/charts/mattermost-enterprise-edition/values.yaml
+++ b/charts/mattermost-enterprise-edition/values.yaml
@@ -253,6 +253,8 @@ mattermostApp:
   envFrom: []
   ## Additional pod annotations
   extraPodAnnotations: {}
+  ## Additional pod labels
+  extraPodLabels: {}
 # MySQL HA Section. Use this to configure MySQL.
 # If you are using an external DB, disable this.
 mysqlha:

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
+        {{- if .Values.extraPodLabels }}
+        {{- .Values.extraPodLabels | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -123,6 +123,9 @@ mysql:
 ## Additional pod annotations
 extraPodAnnotations: {}
 
+## Additional pod labels
+extraPodLabels: {}
+
 ## Additional env vars
 extraEnvVars: []
   # This is an example of extra env vars when using with the deployment with GitLab Helm Charts


### PR DESCRIPTION
The current deployment lacks the ability to set pod labels. While this may not directly affect the usage of Mattermost, it is a common feature needed in bigger environments. This adds the ability to set them
