### PR TITLE
fix security context at container level in hardened k8s cluster

### DIFF
--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -41,9 +41,9 @@ spec:
       tolerations:
       {{- toYaml .Values.tolerations | nindent 6 }}
       {{- end }}
-      {{- if .Values.securityContext }}
+      {{- if .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
@@ -107,9 +107,9 @@ spec:
         {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 12 }}
-        {{- if .Values.podSecurityContext }}
+        {{- if .Values.securityContext }}
         securityContext:
-          {{- toYaml .Values.podSecurityContext | nindent 10 }}
+          {{- toYaml .Values.securityContext | nindent 10 }}
         {{- end }}
       volumes:
       {{- if .Values.extraVolumes -}}

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
         {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 12 }}
+        {{- if .Values.podSecurityContext }}
+        securityContext:
+          {{- toYaml .Values.podSecurityContext | nindent 10 }}
+        {{- end }}
       volumes:
       {{- if .Values.extraVolumes -}}
       {{ .Values.extraVolumes | toYaml | nindent 6 }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -210,6 +210,17 @@ affinity: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
+## Pod Security Context
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext:
+  # fsGroup: 2000
+  # fsGroupChangePolicy: Always
+  # runAsGroup: 2000
+  # runAsNonRoot: true
+  # runAsUser: 2000
+  # seccompProfile:
+  #   type: RuntimeDefault
+
 ## Container Security Context
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
@@ -217,17 +228,6 @@ securityContext:
   # capabilities:
   #   drop:
   #   - ALL
-  # runAsGroup: 2000
-  # runAsNonRoot: true
-  # runAsUser: 2000
-  # seccompProfile:
-  #   type: RuntimeDefault
-
-## Pod Security Context
-## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-podSecurityContext:
-  # fsGroup: 2000
-  # fsGroupChangePolicy: Always
   # runAsGroup: 2000
   # runAsNonRoot: true
   # runAsUser: 2000

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -210,12 +210,29 @@ affinity: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
-## Pod Security Context
+## Container Security Context
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
-  # fsGroup: 2000
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #   - ALL
   # runAsGroup: 2000
+  # runAsNonRoot: true
   # runAsUser: 2000
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+## Pod Security Context
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext:
+  # fsGroup: 2000
+  # fsGroupChangePolicy: Always
+  # runAsGroup: 2000
+  # runAsNonRoot: true
+  # runAsUser: 2000
+  # seccompProfile:
+  #   type: RuntimeDefault
 
 serviceAccount:
   create: false


### PR DESCRIPTION
#### Summary
When we try to deploy [mattermost-team-edition] with helm charts into a hardened k8s cluster, it's not possible to define a custom securityContext at the container level (event if it's possible at pod level but it's not enough to start the mattermost-team-edition pod).
We have to add some custom securityContext definition on the deployment at the container level.

The fix done here, is supposed to be backward compatible.

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-helm/issues/315
