### PR TITLE
Update calls-offloader chart

### DIFF
--- a/charts/mattermost-calls-offloader/Chart.yaml
+++ b/charts/mattermost-calls-offloader/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mattermost-calls-offloader
 description: A Helm chart for Kubernetes to deploy Mattermost's Calls Offloader service
 type: application
-version: 0.2.0
-appVersion: "0.8.0"
+version: 0.2.1
+appVersion: "0.9.0"
 keywords:
 - mattermost
 - calls-offloader

--- a/charts/mattermost-calls-offloader/templates/deployment.yaml
+++ b/charts/mattermost-calls-offloader/templates/deployment.yaml
@@ -55,36 +55,6 @@ spec:
               port: offloader
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            {{- if .Values.volumeConfig.usePVC }}
-            - mountPath: {{ .Values.persistentVolume.mountPath }}
-              name: {{ .Values.persistentVolume.name }}
-            {{- end }}
-            {{- if .Values.volumeConfig.useEFS }}
-            - mountPath: {{ .Values.efsVolume.mountPath }}
-              name: {{ .Values.efsVolume.name }}
-            {{- end }}
-            {{- if .Values.volumeConfig.useNFS }}
-            - mountPath: {{ .Values.nfsVolume.mountPath }}
-              name: {{ .Values.nfsVolume.name }}
-            {{- end }}
-      volumes:
-        {{- if .Values.volumeConfig.usePVC }}
-        - name: {{ .Values.persistentVolume.name }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.persistentVolume.claimName }}
-        {{- end }}
-        {{- if .Values.volumeConfig.useEFS }}
-        - name: {{ .Values.efsVolume.name }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.efsVolume.claimName }}
-        {{- end }}
-        {{- if .Values.volumeConfig.useNFS }}
-        - name: {{ .Values.nfsVolume.name }}
-          nfs:
-            server: {{ .Values.nfsVolume.server }}
-            path: {{ .Values.nfsVolume.path }}
-        {{- end }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/mattermost-calls-offloader/values.yaml
+++ b/charts/mattermost-calls-offloader/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: mattermost/calls-offloader
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.8.0"
+  tag: "v0.9.0"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -83,6 +83,9 @@ config:
     value: "true"
   - name: LOGGER_CONSOLELEVEL
     value: "INFO"
+  # To be set in case a persistent volume is used.
+  # - name: JOBS_KUBERNETES_PERSISTENTVOLUMECLAIMNAME
+  #   value: "my-pvc"
 
 volumeConfig:
   usePVC: false


### PR DESCRIPTION
#### Summary

Updating the `calls-offloader` chart to:

- Include the necessary environment variable needed by jobs to use persistent volumes. 
- Remove the volume mounts for the offloader service itself since it doesn't need to persist data.
- Use the [latest v0.9.0 image](https://hub.docker.com/layers/mattermost/calls-offloader/v0.9.0/images/sha256-1284ea8a453d3e447df53f304857803c20033f3f422659a6e902d320d00d5dbf)


