### PR TITLE
Add yaml document separators to CRDs to make `helm show crds` valid

### DIFF
--- a/charts/mattermost-operator/crds/crd-clusterinstallations.yaml
+++ b/charts/mattermost-operator/crds/crd-clusterinstallations.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/mattermost-operator/crds/crd-mattermostrestoredbs.yaml
+++ b/charts/mattermost-operator/crds/crd-mattermostrestoredbs.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/mattermost-operator/crds/crd-mattermosts.yaml
+++ b/charts/mattermost-operator/crds/crd-mattermosts.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Modern helm has command `show crds` to get CRDs from chart without untarring etc:
```sh
helm show crds mattermost/mattermost-operator
```
It concatenates files from `crds/`, thus currently produces invalid yaml for mattermost-operator (with keys redefinition).

Helm has [a proposal](https://github.com/helm/helm/pull/12624) to forcefully add separators, but it was not accepted for more than a year at the moment and it's not clear when and if it will be.

This PR makes helm's output valid and useable