### PR TITLE
Support pathType in Ingress

### DIFF
--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -135,6 +135,8 @@ Parameter                             | Description                             
 `ingress.enabled`                     | If `true`, an ingress is created                                                                | `false`
 `ingress.hosts`                       | A list of ingress hosts                                                                         | `[mattermost.example.com]`
 `ingress.tls`                         | A list of [ingress tls](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) items | `[]`
+`ingress.path`                        | The ingress path                                                                                | `/`
+`ingress.pathType`                    | The ingress path type                                                                           | `Prefix`
 `mysql.enabled`                       | Enables deployment of a mysql server                                                            | `true`
 `mysql.mysqlRootPassword`             | Root Password for Mysql (Optional)                                                              | ""
 `mysql.mysqlUser`                     | Username for Mysql (Required)                                                                   | ""

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
             name: {{ $serviceName }}
             port:
               number: {{ $servicePort }}
-        pathType: Prefix
+        pathType: {{ $.Values.ingress.pathType }}
         {{- else }}
         backend:
           serviceName: {{ $serviceName }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -58,6 +58,7 @@ ingress:
   enabled: false
   className: ""
   path: /
+  pathType: Prefix
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # certmanager.k8s.io/issuer:  your-issuer


### PR DESCRIPTION
#### Summary

The Ingress template for _Mattermost Teams_ does not presently support overriding the `pathType`. In order to use Nginx path-based routing with regex's etc, you need to be able to specify `pathType: ImplementationSpecific`

#### Ticket Link

Relates to https://github.com/mattermost/mattermost-helm/issues/491
