### PR TITLE
CLD-9041: Update READMEs with operator recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,19 @@
 
 This repository collects a set of [Helm](https://helm.sh) charts curated by [Mattermost](https://www.mattermost.com).
 
-Click on the following links to see installation instructions for each chart:
+## Charts
 
-- [focalboard](charts/focalboard/)
-- [mattermost-chaos-engine](charts/mattermost-chaos-engine/)
-- [mattermost-enterprise-edition](charts/mattermost-enterprise-edition/)
+If you are looking to deploy Mattermost, start with the official Mattermost Operator helm chart:
+
 - [mattermost-operator](charts/mattermost-operator/)
-- [mattermost-push-proxy](charts/mattermost-push-proxy/)
+
+Other charts are provided which support or extend existing deployments:
+
 - [mattermost-rtcd](charts/mattermost-rtcd/)
-- [mattermost-team-edition](charts/mattermost-team-edition/)
+- [mattermost-calls-offloader](charts/mattermost-calls-offloader/)
+- [mattermost-push-proxy](charts/mattermost-push-proxy/)
+- [mattermost-chaos-engine](charts/mattermost-chaos-engine/)
+- [focalboard](charts/focalboard/)
 
 ## Usage
 

--- a/charts/mattermost-enterprise-edition/README.md
+++ b/charts/mattermost-enterprise-edition/README.md
@@ -1,5 +1,6 @@
-Mattermost Enterprise Edition Helm Chart
-====================================================
+# Mattermost Enterprise Edition Helm Chart
+
+> :warning: **For new Mattermost deployments, we strongly recommend our [mattermost-operator](charts/mattermost-operator/) helm chart.**
 
 This is the Helm chart for the Mattermost Enterprise Edition. It is subject to changes, but is used by Mattermost internally to run CI servers and our [community.mattermost.com](https://community.mattermost.com) server. To learn more about Helm charts, [see the Helm docs](https://helm.sh/docs/).
 

--- a/charts/mattermost-operator/README.md
+++ b/charts/mattermost-operator/README.md
@@ -1,19 +1,18 @@
-Mattermost Operator Helm Chart
-====================================================
+# Mattermost Operator Helm Chart
 
-This is the Helm chart for the Mattermost Operator. To learn more about Helm charts, [see the Helm docs](https://helm.sh/docs/). You can find more information about Mattermost Operator [here](https://github.com/mattermost/mattermost-operator/blob/master/README.md).
+This is the Helm chart for the Mattermost Operator which is the recommended way to deploy Mattermost in Kubernetes. [Documentation is provided here](https://docs.mattermost.com/install/install-kubernetes.html) which provides extended guidance on using this chart.
 
-The Mattermost Operator source code lives [here](https://github.com/mattermost/mattermost-operator).
+To learn more about Helm charts, [see the Helm docs](https://helm.sh/docs/). You can find more information about Mattermost Operator [here](https://github.com/mattermost/mattermost-operator/blob/master/README.md). The Mattermost Operator source code lives [here](https://github.com/mattermost/mattermost-operator).
 
-# 1. Prerequisites
+## 1. Prerequisites
 
-## 1.1 Kubernetes Cluster
+### 1.1 Kubernetes Cluster
 
 You need a running Kubernetes cluster v1.22+. If you do not have one, find options and installation instructions here:
 
 https://kubernetes.io/docs/home/
 
-## 1.2 Helm
+### 1.2 Helm
 
 See: https://docs.helm.sh/using_helm/#quickstart
 
@@ -25,11 +24,11 @@ Once Helm is installed and initialized, run the following:
 helm repo add mattermost https://helm.mattermost.com
 ```
 
-# 2. Configuration
+## 2. Configuration
 
 To start, copy [mattermost-helm/charts/mattermost-operator/values.yaml](https://github.com/mattermost/mattermost-helm/blob/master/charts/mattermost-operator/values.yaml) and name it `config.yaml`. This will be your configuration file for the Mattermost Operator chart. The default values will deploy the resources necessary to run the Mattermost Operator.
 
-# 3. Install
+## 3. Install
 
 After adding the Mattermost repo (see section 1.2) you can install a version of the preferred chart by running:
 
@@ -52,9 +51,9 @@ To run with your custom `config.yaml`, install using:
 helm install <your-release-name> mattermost/mattermost-operator -f config.yaml -n mattermost-operator
 ```
 
-## 3.1 Upgrade
+### 3.1 Upgrade
 
-### Upgrading the CRDs
+#### Upgrading the CRDs
 
 Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a release, preform the following to ensure you have the appropriate CRDs available.
 
@@ -76,18 +75,18 @@ Helm does not upgrade the CRDs during a release upgrade. Before you upgrade a re
     kubectl apply -f crds/
     ```
 
-### Upgrading the release
+#### Upgrading the release
 
 To upgrade an existing release, modify the `config.yaml` with your desired changes and then use:
 ```console
 helm upgrade -f config.yaml <your-release-name> mattermost/mattermost-operator -n mattermost-operator
 ```
 
-## 3.2 Uninstalling Mattermost Operator Helm Chart
+### 3.2 Uninstalling Mattermost Operator Helm Chart
 
 If you are done with your deployment and want to delete it, use `helm delete <your-release-name>`. If you don't know the name of your release, use `helm ls -A` to find it across all namespaces. Make sure to pass the namespace in the helm delete command.
 
-# 4. Developing
+## 4. Developing
 
 If you are going to modify the helm charts, it is helpful to use `--dry-run` (doesn't do an actual deployment) and `--debug` (print the generated config files) when running `helm install`.
 

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -1,5 +1,7 @@
 # Mattermost Team Edition
 
+> :warning: **For new Mattermost deployments, we strongly recommend our [mattermost-operator](charts/mattermost-operator/) helm chart.**
+
 [Mattermost](https://mattermost.com/) is a hybrid cloud enterprise messaging workspace that brings your messaging and tools together to get more done, faster.
 
 ## TL;DR;


### PR DESCRIPTION
In an effort to streamline helm chart choice decisions, this change does the following:
 - Update main repo README to suggest Operator chart and remove easy links to older charts.
 - Provide callouts at the top of team and enterprise chart READMEs to suggest Operator chart usage.
 - Small formatting updates.

Fixes https://mattermost.atlassian.net/browse/CLD-9041
