### PR TITLE
Add containerSecurityContext to mattermost-team-edition chart

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.74
+version: 6.6.75
 appVersion: 10.7.0
 keywords:
   - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -127,6 +127,7 @@ The following table lists the configurable parameters of the Mattermost Team Edi
 Parameter                             | Description                                                                                     | Default
 ---                                   | ---                                                                                             | ---
 `configJSON`                          | The `config.json` configuration to be used by the mattermost server. The values you provide will by using Helm's merging behavior override individual default values only. See the [example configuration](#example-configuration) and the [Mattermost documentation](https://docs.mattermost.com/administration/config-settings.html) for details. |  See `configJSON` in [values.yaml](https://github.com/helm/charts/blob/master/stable/mattermost-team-edition/values.yaml)
+`containerSecurityContext`            | Security context for the container                                                              | `null`
 `image.repository`                    | Container image repository                                                                      | `mattermost/mattermost-team-edition`
 `image.tag`                           | Container image tag                                                                             | `5.39.0`
 `image.imagePullPolicy`               | Container image pull policy                                                                     | `IfNotPresent`
@@ -148,6 +149,7 @@ Parameter                             | Description                             
 `extraPodAnnotations`                 | Extra pod annotations to be used in the deployments                                             | `[]`
 `extraEnvVars`                        | Extra environments variables to be used in the deployments                                      | `[]`
 `extraInitContainers`                 | Additional init containers                                                                      | `[]`
+`securityContext`                     | Security context for the pod                                                                    | `null`
 `service.annotations`                 | Service annotations                                                                             | `{}`
 `service.loadBalancerIP`              | A user-specified IP address for service type LoadBalancer to use as External IP (if supported)  | `nil`
 `service.loadBalancerSourceRanges`    | list of IP CIDRs allowed access to load balancer (if supported)                                 | `[]`

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
         {{- end }}
         resources:
           {{- .Values.resources | toYaml | nindent 12 }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       {{- if .Values.extraVolumes -}}
       {{ .Values.extraVolumes | toYaml | nindent 6 }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -217,6 +217,18 @@ securityContext:
   # runAsGroup: 2000
   # runAsUser: 2000
 
+## Mattermost container Security Context
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+containerSecurityContext:
+  # allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # seccompProfile:
+  #   type: RuntimeDefault
+
 serviceAccount:
   create: false
   name:


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

The `containerSecurityContext` parameter enables the chart to be deployed to kubernetes clusters with hardened security policies.

Original discussion https://github.com/mattermost/mattermost-helm/pull/482

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

- Fixes https://github.com/mattermost/mattermost-helm/issues/315
- Closes https://github.com/mattermost/mattermost-helm/pull/482