### PR TITLE
support NodePort alternative to hostnetwork for RTCD chart

### DIFF
--- a/charts/mattermost-rtcd/templates/daemonset.yaml
+++ b/charts/mattermost-rtcd/templates/daemonset.yaml
@@ -29,7 +29,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
+      {{- if .Values.configuration.hostNetwork }}
       hostNetwork: true
+      {{- end }}
       serviceAccountName: {{ include "mattermost-rtcd.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.configuration.terminationGracePeriod }}
       securityContext:

--- a/charts/mattermost-rtcd/templates/deployment.yaml
+++ b/charts/mattermost-rtcd/templates/deployment.yaml
@@ -30,7 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
+      {{- if .Values.configuration.hostNetwork }}
       hostNetwork: true
+      {{- end }}
       serviceAccountName: {{ include "mattermost-rtcd.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.configuration.terminationGracePeriod }}
       securityContext:

--- a/charts/mattermost-rtcd/templates/service.yaml
+++ b/charts/mattermost-rtcd/templates/service.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "mattermost-rtcd.labels" . | nindent 4 }}
 spec:
+  {{- if or Values.configuration.hostNetwork.enabled (eq .Values.service.NodePort.enabled false) }}
   clusterIP: None
+  {{- else }}
+  type: NodePort
+  {{- end }}
   ports:
     - port: {{ .Values.service.APIport }}
       targetPort: api
@@ -15,6 +19,9 @@ spec:
       targetPort: rtc-udp
       protocol: UDP
       name: rtc-udp
+      {{- if and .Values.service.NodePort.enabled .Values.service.NodePort.udpNodePort }}
+      nodePort: {{ .Values.service.NodePort.udpNodePort }}
+      {{- end }}
     - port: {{ .Values.service.RTCport }}
       targetPort: rtc-tcp
       protocol: TCP

--- a/charts/mattermost-rtcd/values.yaml
+++ b/charts/mattermost-rtcd/values.yaml
@@ -64,11 +64,20 @@ configuration:
     #   readOnly: true
   ## Allows the specification of additional environment variables for Mattermost
 
+  # Set to false if you want to disable hostNetwork
+  hostNetwork: true
+
 service:
   # APIport is the port that websocket and API uses
   APIport: 8045
   # RTCport is the port (both UDP and TCP) that will serve calls related traffic (i.e. audio,video)
   RTCport: 8443
+
+  # NodePort configuration. If enabled, disables hostNetwork
+  NodePort:
+    enabled: false
+    # if left empty, NodePort port assignment will be random
+    udpNodePort: ""
 
 ingress:
   enabled: false


### PR DESCRIPTION
#### Summary
RTCD requires direct UDP access from the client (running outside the cluster). This means the client needs to be able to reach the RTCD pod(s) directly via a configurable UDP port.

The default mechanism RTCD handles this via the chart is to turn on `hostNetwork: true` in the deployment/daemonset and to create a headless service. The implications required here for your client to reach RTCD over UDP now mean RTCD will have access to the underlying node network stack and require the node be reachable via the client.

Both of these factors go against best practice with Kubernetes networking and also are not required. I am working another PR for the documentation [here](https://docs.mattermost.com/configure/calls-deployment.html#id2) to further elaborate, but the basic premise is you can use a NodePort instead of `hostNetwork` to expose your application. Further, you can put an external LB in front of the cluster to protect the nodes and just forward UDP/8443 to the nodeport via the LB.

The last part is optional, but the nodeport paradigm is impossible without forking the chart (or in our case using flux to postrenderer - egh). This PR maintains the default posture of hostnetwork and headless service, but simply makes them configurable if you would prefer the nodeport route.

#### Ticket Link
no ticket link

