### PR TITLE
non-operator chart: Add Size presets and optional DB readiness init container

### DIFF
--- a/charts/mattermost/Chart.yaml
+++ b/charts/mattermost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost enterprise edition server deployment without Mattermost Operator.
 name: mattermost
 type: application
-version: 2.7.0
+version: 2.8.0
 appVersion: 11.1.1
 keywords:
 - mattermost

--- a/charts/mattermost/templates/_helpers.tpl
+++ b/charts/mattermost/templates/_helpers.tpl
@@ -59,3 +59,112 @@ Return the appropriate apiVersion for ingress. Based on
 {{- define "mattermost.deployment.apiVersion" -}}
 "apps/v1"
 {{- end -}}
+
+{{/*
+Size presets for the Mattermost app pods.
+
+These mirror the App-row of the operator's `Size` table
+(apis/mattermost/v1alpha1/clusterinstallation_sizes.go) so users get the same
+sizing UX in the chart as they do via the CRD. The chart only sizes the
+Mattermost app pods - database and object storage are external.
+
+If `mattermostApp.size` is set to one of the keys below, it derives both
+`replicas` and `resources` for the app deployment. Explicit values for
+`mattermostApp.replicaCount` and `mattermostApp.resources` always win.
+
+Supported keys: 100users, 1000users, 5000users, 10000users, 25000users.
+*/}}
+{{- define "mattermost.app.sizes" -}}
+100users:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+1000users:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 150m
+      memory: 256Mi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+5000users:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+    limits:
+      cpu: 4000m
+      memory: 8Gi
+10000users:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 500m
+      memory: 500Mi
+    limits:
+      cpu: 4000m
+      memory: 8Gi
+25000users:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 4Gi
+    limits:
+      cpu: 4000m
+      memory: 16Gi
+{{- end -}}
+
+{{/*
+Resolve the sizing preset selected by the user, or an empty dict if none.
+*/}}
+{{- define "mattermost.app.size" -}}
+{{- $size := default "" .Values.mattermostApp.size -}}
+{{- if $size -}}
+{{- $sizes := fromYaml (include "mattermost.app.sizes" .) -}}
+{{- $preset := index $sizes $size -}}
+{{- if not $preset -}}
+{{- fail (printf "mattermostApp.size %q is not a known preset. Valid keys: 100users, 1000users, 5000users, 10000users, 25000users" $size) -}}
+{{- end -}}
+{{- toYaml $preset -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Effective replica count for the Mattermost app deployment.
+
+Mirrors the operator's semantics: when `mattermostApp.size` is set, the
+preset is authoritative and overrides `replicaCount`. To override manually,
+leave `mattermostApp.size` empty and use `mattermostApp.replicaCount`.
+*/}}
+{{- define "mattermost.app.effectiveReplicas" -}}
+{{- $preset := fromYaml (include "mattermost.app.size" .) -}}
+{{- if $preset -}}
+{{- $preset.replicas -}}
+{{- else -}}
+{{- .Values.mattermostApp.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Effective resource requirements for the Mattermost app container.
+
+Mirrors the operator's semantics: when `mattermostApp.size` is set, the
+preset is authoritative and overrides `resources`. To override manually,
+leave `mattermostApp.size` empty and use `mattermostApp.resources`.
+*/}}
+{{- define "mattermost.app.effectiveResources" -}}
+{{- $preset := fromYaml (include "mattermost.app.size" .) -}}
+{{- if $preset -}}
+{{- toYaml $preset.resources -}}
+{{- else -}}
+{{- toYaml .Values.mattermostApp.resources -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mattermost/templates/_helpers.tpl
+++ b/charts/mattermost/templates/_helpers.tpl
@@ -68,9 +68,12 @@ These mirror the App-row of the operator's `Size` table
 sizing UX in the chart as they do via the CRD. The chart only sizes the
 Mattermost app pods - database and object storage are external.
 
-If `mattermostApp.size` is set to one of the keys below, it derives both
-`replicas` and `resources` for the app deployment. Explicit values for
-`mattermostApp.replicaCount` and `mattermostApp.resources` always win.
+If `mattermostApp.size` is set to one of the keys below, the helpers
+`mattermost.app.effectiveReplicas` and `mattermost.app.effectiveResources`
+derive replicas and resources from the matching preset, and the preset is
+authoritative - it overrides `mattermostApp.replicaCount` and
+`mattermostApp.resources`. To size the deployment manually, leave
+`mattermostApp.size` empty.
 
 Supported keys: 100users, 1000users, 5000users, 10000users, 25000users.
 */}}

--- a/charts/mattermost/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost/templates/deployment-mattermost-app.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart:  {{ include "mattermost.chart" . }}
 spec:
   {{- if not .Values.mattermostApp.autoscaling.enabled }}
-  replicas: {{ .Values.mattermostApp.replicaCount }}
+  replicas: {{ include "mattermost.app.effectiveReplicas" . }}
   {{- end }}
   {{- with .Values.mattermostApp.strategy }}
   strategy:
@@ -62,9 +62,35 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.mattermostApp.imagePullSecrets | nindent 6 }}
       {{- end }}
-      {{- if .Values.mattermostApp.extraInitContainers }}
+      {{- if or .Values.mattermostApp.dbReadinessCheck.enabled .Values.mattermostApp.extraInitContainers }}
       initContainers:
+      {{- if .Values.mattermostApp.dbReadinessCheck.enabled }}
+      - name: init-check-database
+        image: {{ .Values.mattermostApp.dbReadinessCheck.image | quote }}
+        imagePullPolicy: {{ .Values.mattermostApp.dbReadinessCheck.imagePullPolicy }}
+        env:
+        - name: DB_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+            {{- if and .Values.global.features.database.existingDatabaseSecret .Values.global.features.database.existingDatabaseSecret.name }}
+              name: {{ .Values.global.features.database.existingDatabaseSecret.name }}
+              key: {{ .Values.global.features.database.existingDatabaseSecret.key }}
+            {{- else }}
+              name: {{ include "mattermost.fullname" . }}-mattermost-dbsecret
+              key: mattermost.dbsecret
+            {{- end }}
+        command:
+        - sh
+        - -c
+        - |
+          until pg_isready --timeout={{ .Values.mattermostApp.dbReadinessCheck.timeoutSeconds }} --dbname="$DB_CONNECTION_STRING"; do
+            echo "waiting for database";
+            sleep {{ .Values.mattermostApp.dbReadinessCheck.intervalSeconds }};
+          done
+      {{- end }}
+      {{- if .Values.mattermostApp.extraInitContainers }}
       {{- .Values.mattermostApp.extraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ include "mattermost.name" . }}
@@ -172,7 +198,7 @@ spec:
 {{ toYaml .Values.mattermostApp.extraVolumeMounts | indent 8 }}
 {{- end }}
         resources:
-{{ toYaml .Values.mattermostApp.resources | indent 10 }}
+{{ include "mattermost.app.effectiveResources" . | indent 10 }}
       volumes:
       - name: mattermost-plugins
         emptyDir: {}

--- a/charts/mattermost/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost/templates/deployment-mattermost-app.yaml
@@ -109,7 +109,7 @@ spec:
         - name: MM_CONFIG
           valueFrom:
             secretKeyRef:
-           {{- if .Values.global.features.database.existingDatabaseSecret }}
+           {{- if and .Values.global.features.database.existingDatabaseSecret .Values.global.features.database.existingDatabaseSecret.name }}
               name: {{ .Values.global.features.database.existingDatabaseSecret.name }}
               key: {{ .Values.global.features.database.existingDatabaseSecret.key }}
            {{- else }}

--- a/charts/mattermost/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost/templates/deployment-mattermost-app.yaml
@@ -73,8 +73,9 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if and .Values.global.features.database.existingDatabaseSecret .Values.global.features.database.existingDatabaseSecret.name }}
+              {{- $dbSecretKey := required "global.features.database.existingDatabaseSecret.key is required when global.features.database.existingDatabaseSecret.name is set" .Values.global.features.database.existingDatabaseSecret.key }}
               name: {{ .Values.global.features.database.existingDatabaseSecret.name }}
-              key: {{ .Values.global.features.database.existingDatabaseSecret.key }}
+              key: {{ $dbSecretKey }}
             {{- else }}
               name: {{ include "mattermost.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret
@@ -110,8 +111,9 @@ spec:
           valueFrom:
             secretKeyRef:
            {{- if and .Values.global.features.database.existingDatabaseSecret .Values.global.features.database.existingDatabaseSecret.name }}
+              {{- $dbSecretKey := required "global.features.database.existingDatabaseSecret.key is required when global.features.database.existingDatabaseSecret.name is set" .Values.global.features.database.existingDatabaseSecret.key }}
               name: {{ .Values.global.features.database.existingDatabaseSecret.name }}
-              key: {{ .Values.global.features.database.existingDatabaseSecret.key }}
+              key: {{ $dbSecretKey }}
            {{- else }}
               name: {{ include "mattermost.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret

--- a/charts/mattermost/values.yaml
+++ b/charts/mattermost/values.yaml
@@ -57,8 +57,18 @@ global:
       tolerations: []
       extraEnv: []
 
+
 # Mattermost deployment section.
 mattermostApp:
+  # OPTIONAL: Sizing preset that derives replicas + resource requests/limits
+  # for the Mattermost app pods. Mirrors the App row of the operator's Size
+  # presets (apis/mattermost/v1alpha1/clusterinstallation_sizes.go).
+  # Valid values: "" (default - use replicaCount + resources below),
+  # "100users", "1000users", "5000users", "10000users", "25000users".
+  # When set, the preset is AUTHORITATIVE and overrides replicaCount and
+  # resources below (matching the operator's behaviour). Leave empty if you
+  # want to size the deployment manually.
+  size: ""
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
@@ -134,6 +144,23 @@ mattermostApp:
     requests:
       cpu: 100m
       memory: 300Mi
+
+  # OPTIONAL: Database readiness init container.
+  # When enabled, an init container runs before the Mattermost app container
+  # starts and blocks until the database accepts connections. Mirrors the
+  # operator's behaviour for external databases.
+  #
+  # For PostgreSQL, the chart uses pg_isready against the connection string
+  # found in the database secret (key MM_CONFIG, or existingDatabaseSecret.key).
+  dbReadinessCheck:
+    enabled: false
+    # Image used for the readiness probe.
+    image: postgres:16-alpine
+    imagePullPolicy: IfNotPresent
+    # Optional: timeout (seconds) for each pg_isready attempt.
+    timeoutSeconds: 5
+    # Optional: sleep (seconds) between attempts.
+    intervalSeconds: 5
 
   extraInitContainers: []
   extraVolumes: []


### PR DESCRIPTION
## Summary

Bumps `charts/mattermost` to 2.8.0 and brings two operator features, Size presets and a DB readiness init container to the non-operator chart introduced in #513.

The goal is feature parity, so the same chart can back our Kubernetes Marketplace listings on AWS, Azure (incl. Azure Local), GCP, and OCI. Defaults are unchanged; every new field is opt-in.

Changes
-------
- **Size presets for the app pods** (mattermostApp.size): "100users",   "1000users", "5000users", "10000users", "25000users". Mirrors the App row of the operator's Size table ([apis/mattermost/v1alpha1/clusterinstallation_sizes.go](https://github.com/mattermost/mattermost-operator/blob/37e2de22da8d9a21b5ba8152d137f3646c72c450/apis/mattermost/v1alpha1/clusterinstallation_sizes.go#L22-L279)). When set, the preset is authoritative and overrides replicaCount and resources, matching the operator. 

- **Optional database readiness init container** (mattermostApp.dbReadinessCheck): When enabled, an init container runs `pg_isready` against the same secret the app reads its connection string  from, blocking the main container until PostgreSQL is reachable. Mirrors the operator's [init-check-database for external databases](https://github.com/mattermost/mattermost-operator/blob/37e2de22da8d9a21b5ba8152d137f3646c72c450/pkg/mattermost/database_external.go#L107). Removes the first-install CrashLoopBackOff that managed-DB customers see while DNS / IRSA / Cloud SQL Auth Proxy / NSG warmup settles.

- Fix of 2 #513 bugs  in how the chart resolves `existingDatabaseSecret`: default installs no longer render empty `secretKeyRef.name`/`key`, and setting `name` without `key` now fails fast at `helm install`/`upgrade` with a clear error instead of an API-server rejection. The same logic is now shared between the new DB readiness init container and the existing main-container env.