### PR TITLE
Non-Operator Chart: Support existing PVC as filestore via global.features.fileStore.existingVolumeClaim 

### DIFF
--- a/charts/mattermost/Chart.yaml
+++ b/charts/mattermost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost enterprise edition server deployment without Mattermost Operator.
 name: mattermost
 type: application
-version: 2.8.0
+version: 2.9.0
 appVersion: 11.1.1
 keywords:
 - mattermost

--- a/charts/mattermost/README.md
+++ b/charts/mattermost/README.md
@@ -101,6 +101,7 @@ mattermostApp:
 4. `global.features.database.dataSource` - Database connection string
 5. `global.features.fileStore.driver` - File storage driver: `amazons3` or `local`
 6. `global.features.fileStore.bucket` - S3 bucket name (when using `amazons3`)
+7. `global.features.fileStore.existingVolumeClaim.name` - Existing PVC name (when using `local`)
 
 ## 2.2 Database Configuration
 
@@ -121,13 +122,62 @@ global:
 
 ## 2.3 File Storage Configuration
 
-Configure S3-compatible storage via environment variables in `mattermostApp.extraEnv`. Create a Kubernetes secret for credentials:
+The chart supports two file storage drivers, selected via
+`global.features.fileStore.driver`:
+
+| Driver | Backing store | Notes |
+|---|---|---|
+| `amazons3` | AWS S3 or any S3-compatible object store | Default driver. |
+| `local` | A pre-existing PersistentVolumeClaim (NFS, Azure Files NFS, AWS EFS, GCP Filestore, OCI File Storage, on-prem NFS / CephFS, etc.) | The chart does **not** provision the PVC - you create it out-of-band and pass its name in. |
+
+### 2.3.1 S3-compatible storage (`amazons3`)
+
+Create a Kubernetes secret with your credentials and reference it from values:
 
 ```bash
 kubectl create secret generic mattermost-s3-credentials \
-  --from-literal=access-key-id=YOUR_ACCESS_KEY \
-  --from-literal=secret-access-key=YOUR_SECRET_KEY
+  --from-literal=accessKeyId=YOUR_ACCESS_KEY \
+  --from-literal=secretAccessKey=YOUR_SECRET_KEY
 ```
+
+```yaml
+global:
+  features:
+    fileStore:
+      driver: "amazons3"
+      bucket: "my-mattermost-bucket"
+      region: "us-east-1"
+      existingSecret:
+        name: "mattermost-s3-credentials"
+        accessKeyIdKey: "accessKeyId"
+        secretAccessKeyKey: "secretAccessKey"
+```
+
+### 2.3.2 Using an existing PersistentVolumeClaim (NFS, Azure Files, EFS, etc.)
+
+When `driver` is `"local"`, the chart mounts a customer-provisioned PVC at
+the Mattermost data directory and sets
+`MM_FILESETTINGS_DRIVERNAME=local` /
+`MM_FILESETTINGS_DIRECTORY=<mountPath>/` automatically. Mirrors the
+operator's `Spec.FileStore.ExternalVolume.VolumeClaimName` behaviour.
+
+```yaml
+global:
+  features:
+    fileStore:
+      driver: "local"
+      existingVolumeClaim:
+        name: "mattermost-data-pvc"        # REQUIRED - PVC you provisioned
+        mountPath: "/mattermost/data"      # Optional, default shown
+```
+
+The chart does not create the PVC. Provision it (and any underlying
+StorageClass, file share, mount targets, etc.) yourself, then pass its
+name in `existingVolumeClaim.name`. If the PVC name is empty while
+`driver` is `"local"`, template rendering fails fast with a clear error.
+
+For HA / multi-replica deployments the PVC must support `ReadWriteMany`
+- see [section 5](#5-scaling) for details.
 
 ## 2.4 Ingress (Optional)
 
@@ -247,7 +297,7 @@ Or scale directly with kubectl:
 kubectl scale deployment mattermost --replicas=5
 ```
 
-**Note:** For multi-replica deployments, ensure your file storage is accessible from all pods (use S3-compatible storage, not local).
+**Note:** For multi-replica deployments, ensure your file storage is accessible from all pods. Either use S3-compatible storage (`driver: amazons3`), or use `driver: local` with an `existingVolumeClaim` whose PVC supports `ReadWriteMany` (Azure Files, EFS, GCP Filestore, NFS, CephFS, etc.).
 
 ## 5.2 Horizontal Pod Autoscaler (HPA) - Optional
 

--- a/charts/mattermost/templates/_helpers.tpl
+++ b/charts/mattermost/templates/_helpers.tpl
@@ -171,3 +171,13 @@ leave `mattermostApp.size` empty and use `mattermostApp.resources`.
 {{- toYaml .Values.mattermostApp.resources -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve the mount path for the local (PVC) filestore. Mirrors the operator's
+`mmv1beta.DefaultLocalFilePath` ("/mattermost/data") used by
+ExternalVolumeFileStore.
+*/}}
+{{- define "mattermost.fileStore.localMountPath" -}}
+{{- $claim := default (dict) .Values.global.features.fileStore.existingVolumeClaim -}}
+{{- default "/mattermost/data" $claim.mountPath -}}
+{{- end -}}

--- a/charts/mattermost/templates/deployment-mattermost-app.yaml
+++ b/charts/mattermost/templates/deployment-mattermost-app.yaml
@@ -160,6 +160,12 @@ spec:
         - name: MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY
           value: "{{ .Values.global.features.fileStore.secretAccessKey }}"
         {{- end }}
+{{- else if eq .Values.global.features.fileStore.driver "local" }}
+        {{- $_ := required "global.features.fileStore.existingVolumeClaim.name is required when global.features.fileStore.driver is \"local\"" .Values.global.features.fileStore.existingVolumeClaim.name }}
+        - name: MM_FILESETTINGS_DRIVERNAME
+          value: "local"
+        - name: MM_FILESETTINGS_DIRECTORY
+          value: "{{ include "mattermost.fileStore.localMountPath" . }}/"
 {{- end }}
 {{- with .Values.mattermostApp.extraEnv }}
 {{ toYaml . | indent 8 }}
@@ -196,6 +202,10 @@ spec:
           name: mattermost-plugins
         - mountPath: /mattermost/client/plugins/
           name: mattermost-plugins-client
+        {{- if eq .Values.global.features.fileStore.driver "local" }}
+        - mountPath: {{ include "mattermost.fileStore.localMountPath" . }}
+          name: mattermost-data
+        {{- end }}
 {{- if .Values.mattermostApp.extraVolumeMounts }}
 {{ toYaml .Values.mattermostApp.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -215,6 +225,11 @@ spec:
           {{- else }}
           secretName: {{ include "mattermost.fullname" . }}-mattermost-license
           {{- end }}
+      {{- if eq .Values.global.features.fileStore.driver "local" }}
+      - name: mattermost-data
+        persistentVolumeClaim:
+          claimName: {{ required "global.features.fileStore.existingVolumeClaim.name is required when global.features.fileStore.driver is \"local\"" .Values.global.features.fileStore.existingVolumeClaim.name }}
+      {{- end }}
 {{- if .Values.mattermostApp.extraVolumes }}
 {{ toYaml .Values.mattermostApp.extraVolumes | indent 6 }}
 {{- end }}

--- a/charts/mattermost/templates/deployment-mattermost-jobserver.yaml
+++ b/charts/mattermost/templates/deployment-mattermost-jobserver.yaml
@@ -71,6 +71,13 @@ spec:
               name: {{ include "mattermost.fullname" . }}-mattermost-dbsecret
               key: mattermost.dbsecret
            {{- end }}
+        {{- if eq .Values.global.features.fileStore.driver "local" }}
+        {{- $_ := required "global.features.fileStore.existingVolumeClaim.name is required when global.features.fileStore.driver is \"local\"" .Values.global.features.fileStore.existingVolumeClaim.name }}
+        - name: MM_FILESETTINGS_DRIVERNAME
+          value: "local"
+        - name: MM_FILESETTINGS_DIRECTORY
+          value: "{{ include "mattermost.fileStore.localMountPath" . }}/"
+        {{- end }}
         {{- with .Values.global.features.jobserver.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -84,6 +91,10 @@ spec:
           name: mattermost-license
           subPath: mattermost.mattermost-license
         {{- end }}
+        {{- if eq .Values.global.features.fileStore.driver "local" }}
+        - mountPath: {{ include "mattermost.fileStore.localMountPath" . }}
+          name: mattermost-data
+        {{- end }}
       volumes:
       - name: mattermost-license
         secret:
@@ -92,5 +103,10 @@ spec:
           {{- else }}
           secretName: {{ include "mattermost.fullname" . }}-mattermost-license
           {{- end }}
+      {{- if eq .Values.global.features.fileStore.driver "local" }}
+      - name: mattermost-data
+        persistentVolumeClaim:
+          claimName: {{ required "global.features.fileStore.existingVolumeClaim.name is required when global.features.fileStore.driver is \"local\"" .Values.global.features.fileStore.existingVolumeClaim.name }}
+      {{- end }}
 
 {{- end -}}

--- a/charts/mattermost/values.yaml
+++ b/charts/mattermost/values.yaml
@@ -12,22 +12,26 @@ global:
   features:
     database:
       # Database connection is required. Provide connection details below.
-      driver: "postgres" # postgres
-      dataSource: "" # Connection string - REQUIRED
-      dataSourceReplicas: [] # Optional read replicas
+      driver: "postgres"  # postgres
+      dataSource: ""  # Connection string - REQUIRED
+      dataSourceReplicas: []  # Optional read replicas
       # Use an existing secret for database credentials (see secret-mattermost-dbsecret.yaml for required fields)
       existingDatabaseSecret:
         name:
         key:
 
     fileStore:
-      # External file storage is required for production deployments
-      # For testing, you can use "local" driver (not recommended for production)
-      driver: "amazons3" # amazons3 (S3-compatible), local
+      # File storage driver. Supported values:
+      #   "amazons3" - AWS S3 or any S3-compatible object store.
+      #   "local"    - PersistentVolumeClaim-backed local storage. The chart
+      #                does NOT provision the PVC; supply an existing one
+      #                via existingVolumeClaim below. Mirrors the operator's
+      #                Spec.FileStore.ExternalVolume behaviour.
+      driver: "amazons3"  # amazons3 (S3-compatible), local
       # S3-compatible storage configuration (when driver is "amazons3")
-      url: "" # S3 endpoint (leave empty for AWS S3)
-      bucket: "" # Bucket name - REQUIRED
-      region: "" # AWS region (e.g., us-east-1)
+      url: ""  # S3 endpoint (leave empty for AWS S3)
+      bucket: ""  # Bucket name - REQUIRED
+      region: ""  # AWS region (e.g., us-east-1)
       # Option 1: Provide credentials directly (values.yaml)
       accessKeyId: ""
       secretAccessKey: ""
@@ -36,9 +40,18 @@ global:
       #   --from-literal=accessKeyId=YOUR_KEY \
       #   --from-literal=secretAccessKey=YOUR_SECRET
       existingSecret:
-        name: "" # Name of the Kubernetes Secret (e.g., "mattermost-s3-creds")
-        accessKeyIdKey: "accessKeyId" # Key in the secret containing access key ID
-        secretAccessKeyKey: "secretAccessKey" # Key in the secret containing secret access key
+        name: ""  # Name of the Kubernetes Secret (e.g., "mattermost-s3-creds")
+        accessKeyIdKey: "accessKeyId"  # Key in the secret containing access key ID
+        secretAccessKeyKey: "secretAccessKey"  # Key in the secret containing secret access key
+      # Local (PVC) storage configuration (when driver is "local").
+      # Plug an existing PersistentVolumeClaim (NFS, Azure Files NFS, EFS,
+      # GDC / OCI File Storage, etc.) into the Mattermost data directory.
+      # The chart does NOT create the PVC - customers provision it
+      # out-of-band. For HA / multi-replica deployments the PVC MUST support
+      # ReadWriteMany.
+      existingVolumeClaim:
+        name: ""  # Name of the existing PVC - REQUIRED when driver is "local"
+        mountPath: "/mattermost/data"  # Where to mount the PVC inside the pod
 
     jobserver:
       # Optional: Enable a dedicated job server for background tasks
@@ -92,8 +105,8 @@ mattermostApp:
     externalPort: 8065
     internalPort: 8065
     metricsPort: 8067
-    clusterPort: 8075 # Required for cluster communication between replicas
-    gossipPort: 8074 # Required for gossip protocol between replicas
+    clusterPort: 8075  # Required for cluster communication between replicas
+    gossipPort: 8074  # Required for gossip protocol between replicas
     metricsName: mattermost-app-metrics
 
   ingress:


### PR DESCRIPTION
## Summary

Brings the non-operator `charts/mattermost` chart to parity with the operator's `Spec.FileStore.ExternalVolume.VolumeClaimName` (see [`ExternalVolumeFileStore.Volumes()`](https://github.com/mattermost/mattermost-operator/blob/37e2de22da8d9a21b5ba8152d137f3646c72c450/pkg/mattermost/file_store.go#L55-L74) and [`EnvVars()`](https://github.com/mattermost/mattermost-operator/blob/37e2de22da8d9a21b5ba8152d137f3646c72c450/pkg/mattermost/file_store.go#L47-L49) in `mattermost-operator`). 

When `global.features.fileStore.driver: "local"`, customers can now name an existing PVC and the chart wires up the volume, mount, and `MM_FILESETTINGS_{DRIVERNAME,DIRECTORY}` env vars on both the app and (when enabled) the jobserver Deployments.

Motivated by the upcoming Azure Kubernetes Marketplace listing, where Mattermost has no native Azure Blob driver and customers run on Azure Files NFS via a PVC. 

## Changes

- New `global.features.fileStore.existingVolumeClaim` values block with `name` (required when `driver: "local"`) and optional `mountPath` (default `/mattermost/data`).
- `templates/deployment-mattermost-app.yaml` and `templates/deployment-mattermost-jobserver.yaml` gain a `local` driver branch that appends the volume, mount, and env vars when the driver is set. 
- New `mattermost.fileStore.localMountPath` helper in `_helpers.tpl` so the mount path resolves consistently in both Deployments.

## Design notes

- The chart does not provision the PVC; customers create it out-of-band. Keeps the feature portable across every shared-filesystem backend. Same contract as the operator's `ExternalVolume` mode.
- `existingVolumeClaim.name` is required when `driver: "local"`. Mirrors the operator's validation in [`NewExternalVolumeFileStoreInfo`](https://github.com/mattermost/mattermost-operator/blob/37e2de22da8d9a21b5ba8152d137f3646c72c450/pkg/mattermost/file_store.go#L198-L211).