### PR TITLE
Add Gateway API HTTPRoute support to mattermost-team-edition chart

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Mattermost Team Edition server.
 type: application
 name: mattermost-team-edition
-version: 6.6.104
+version: 6.7.0
 appVersion: 11.9.0
 keywords:
   - mattermost

--- a/charts/mattermost-team-edition/README.md
+++ b/charts/mattermost-team-edition/README.md
@@ -138,6 +138,15 @@ Parameter                             | Description                             
 `ingress.enabled`                     | If `true`, an ingress is created                                                                | `false`
 `ingress.hosts`                       | A list of ingress hosts                                                                         | `[mattermost.example.com]`
 `ingress.tls`                         | A list of [ingress tls](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) items | `[]`
+`httproute.enabled`                   | If `true`, a Gateway API [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) is created | `false`
+`httproute.parentRefs`                | References to the Gateways this HTTPRoute attaches to                                            | `[]`
+`httproute.hostnames`                 | A list of hostnames (templated) the HTTPRoute matches against                                   | `[]`
+`httproute.annotations`               | Annotations to attach to the HTTPRoute resource                                                 | `{}`
+`httproute.labels`                    | Labels to attach to the HTTPRoute resource                                                       | `{}`
+`httproute.httpsRedirect`             | If `true`, emits a single rule redirecting HTTP traffic to HTTPS (301)                          | `false`
+`httproute.additionalRules`           | Custom rules (templated) prepended to the route                                                 | `[]`
+`httproute.filters`                   | Filters applied to requests that match the route                                                | `[]`
+`httproute.matches`                   | Conditions used for matching the rule against incoming requests                                 | `[]`
 `mysql.enabled`                       | Enables deployment of a mysql server                                                            | `true`
 `mysql.mysqlRootPassword`             | Root Password for Mysql (Optional)                                                              | ""
 `mysql.mysqlUser`                     | Username for Mysql (Required)                                                                   | ""

--- a/charts/mattermost-team-edition/templates/httproute.yaml
+++ b/charts/mattermost-team-edition/templates/httproute.yaml
@@ -1,0 +1,46 @@
+{{- $route := .Values.httproute }}
+{{- if $route.enabled }}
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "mattermost-team-edition.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "mattermost-team-edition.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "mattermost-team-edition.chart" . }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ include "mattermost-team-edition.name" . }}
+          port: {{ .Values.service.externalPort }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -84,6 +84,36 @@ ingress:
 route:
   enabled: false
 
+## A HTTPRoute (Gateway API) resource is an alternative to Ingress for routing
+## external HTTP traffic to the Mattermost Service.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+httproute:
+  enabled: false
+  ## apiVersion set by default to gateway.networking.k8s.io/v1
+  apiVersion: ""
+  ## kind set by default to HTTPRoute
+  kind: ""
+  ## Annotations to attach to the HTTPRoute resource
+  annotations: {}
+  ## Labels to attach to the HTTPRoute resource
+  labels: {}
+  ## ParentRefs references the resources (usually Gateways) this HTTPRoute attaches to
+  parentRefs: []
+    # - name: gateway
+    #   namespace: gateway-system
+    #   sectionName: http
+  ## Hostnames (templated) matched against the HTTP Host header to select this HTTPRoute
+  hostnames: []
+    # - mattermost.example.com
+  ## httpsRedirect, when true, emits a single rule that redirects HTTP traffic to HTTPS (301)
+  httpsRedirect: false
+  ## additionalRules (templated) allows prepending custom rules to the route
+  additionalRules: []
+  ## Filters applied to requests that match this route
+  filters: []
+  ## Matches define conditions used for matching the rule against incoming requests
+  matches: []
+
 ## If use this please disable the mysql chart by setting mysql.enable to false
 externalDB:
   enabled: false


### PR DESCRIPTION
Adds an optional Gateway API HTTPRoute resource to the `mattermost-team-edition` chart as an alternative to Ingress for routing external HTTP traffic to the Mattermost Service. Gated behind `httproute.enabled` (default `false`), so existing installs are unaffected. Chart version bumped `6.6.99` → `6.7.0` per the semver contribution requirement in CONTRIBUTING.

The new `templates/httproute.yaml` supports `parentRefs`, templated `hostnames`, `annotations`/`labels`, an `httpsRedirect` shortcut (HTTP→HTTPS 301), and pass-through `additionalRules`/`filters`/`matches`. `backendRefs` target the existing Service (`mattermost-team-edition`) on `service.externalPort` (8065), matching the Ingress backend.

Validation:
- `helm lint` — 1 chart linted, 0 failed
- `helm template` rendered for: disabled (no output), enabled with `parentRefs` + `hostnames`, `httpsRedirect=true` (RequestRedirect filter), and `annotations`/`labels`/`matches`/`filters`

Per CONTRIBUTING ("submit changes to multiple charts in separate PRs"), this covers only `mattermost-team-edition`; the `mattermost-enterprise-edition` chart can follow in a separate PR.