### PR TITLE
Update GDC example values to Mattermost ESR 11.7

### DIFF
--- a/charts/mattermost/Chart.yaml
+++ b/charts/mattermost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: Mattermost enterprise edition server deployment without Mattermost Operator.
 name: mattermost
 type: application
-version: 2.8.0
-appVersion: 11.1.1
+version: 2.8.1
+appVersion: 11.7
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost/examples/gdc/values.yaml
+++ b/charts/mattermost/examples/gdc/values.yaml
@@ -60,7 +60,7 @@ mattermostApp:
 
   image:
     repository: user-haas-instance-user-project.org-1.zone1.google.gdch.test/mattermost/mattermost-enterprise-edition
-    tag: "11.0.2" # Update to the latest version uploaded to Harbor registry
+    tag: "11.7.9" # Update to the latest version uploaded to Harbor registry
     pullPolicy: IfNotPresent
 
   # Image pull secret for private registry

--- a/charts/mattermost/examples/gdc/values.yaml
+++ b/charts/mattermost/examples/gdc/values.yaml
@@ -60,7 +60,7 @@ mattermostApp:
 
   image:
     repository: user-haas-instance-user-project.org-1.zone1.google.gdch.test/mattermost/mattermost-enterprise-edition
-    tag: "11.7.9" # Update to the latest version uploaded to Harbor registry
+    tag: "11.7" # Update to the latest version uploaded to Harbor registry
     pullPolicy: IfNotPresent
 
   # Image pull secret for private registry

--- a/charts/mattermost/values.yaml
+++ b/charts/mattermost/values.yaml
@@ -72,7 +72,7 @@ mattermostApp:
   replicaCount: 2
   image:
     repository: mattermost/mattermost-enterprise-edition
-    tag: 11.1.1@sha256:b795441466ef1b3df0e8a6c5d4f177da7db5d792cba20072f947c693f36442e6
+    tag: 11.7
     pullPolicy: IfNotPresent
   # Image pull secrets for private registries
   imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump the Mattermost image tag in the GDC example values from `11.0.2` to `11.7` so it tracks the current Mattermost Extended Support Release floating tag
- Bump the `mattermost` chart default values and `appVersion` from `11.1.1` to `11.7` (chart version `2.8.0` → `2.8.1`)

## Test plan
- [x] Confirm `charts/mattermost/examples/gdc/values.yaml` uses `mattermostApp.image.tag: "11.7"`
- [x] Confirm `charts/mattermost/values.yaml` uses `mattermostApp.image.tag: 11.7`
- [x] Confirm `charts/mattermost/Chart.yaml` has `appVersion: 11.7` and `version: 2.8.1`
- [ ] Verify the `11.7` image is available in the target Harbor/GDC registry before deploying
- [ ] Optionally dry-run: `helm template mattermost ./charts/mattermost -f charts/mattermost/examples/gdc/values.yaml`
- [ ] Optionally dry-run defaults: `helm template mattermost ./charts/mattermost`